### PR TITLE
Make non-glibc Linux cross-compilation work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nix = { version = "0.29", features = ["fs", "ioctl", "term"] }
 num-traits = "0.2"
 parking_lot = "0.12"
 regex = "1.10"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "charset", "http2"] }
 rustix = { version = "0.38", features = ["fs", "termios"] }
 slotmap = "1.0"
 udev = "0.9"

--- a/mujina-miner/Cargo.toml
+++ b/mujina-miner/Cargo.toml
@@ -49,7 +49,7 @@ ruint = "1.17.0"
 core-foundation = { workspace = true }
 io-kit-sys = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 tracing-journald = { workspace = true }
 udev = { workspace = true }
 

--- a/mujina-miner/src/tracing.rs
+++ b/mujina-miner/src/tracing.rs
@@ -53,7 +53,7 @@ fn build_env_filter() -> EnvFilter {
     filter_str.parse().unwrap()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod journald {
     use std::env;
     use std::io;
@@ -127,7 +127,7 @@ mod journald {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 mod journald {
     pub fn try_init() -> bool {
         false

--- a/mujina-miner/src/transport/usb.rs
+++ b/mujina-miner/src/transport/usb.rs
@@ -25,9 +25,9 @@ use super::TransportEvent as OuterTransportEvent;
 // Platform-specific serial port discovery, aliased to a common name
 // so call sites are platform-independent.
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod linux;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 use linux as platform;
 
 #[cfg(target_os = "macos")]
@@ -39,7 +39,7 @@ use macos as platform;
 // miner still compiles (e.g., for CPU mining). If this is ever
 // called, something has gone wrong because a board matched a USB
 // device on a platform where we can't find its serial ports.
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(all(target_os = "linux", target_env = "gnu"), target_os = "macos")))]
 mod platform {
     use anyhow::{Result, bail};
     use nusb::DeviceInfo;


### PR DESCRIPTION
## Summary

Three small changes that let `mujina-miner` cross-compile for `aarch64-unknown-linux-musl` (and other non-glibc Linux targets), so it can be deployed onto mining hardware that ships with musl userspace — concretely, the Amlogic A113D control board found on Antminer S19 series miners.

- **Switch `reqwest` to `rustls-tls`.** The default features pull in `native-tls`, which transitively requires `openssl-sys`. Cross-building `openssl-sys` to musl is painful (sysroot, pkg-config wrapper, vendored OpenSSL or a sysroot install) and unnecessary when reqwest can use rustls directly.
- **Gate `udev` and `tracing-journald` to `target_env = "gnu"`.** Both link against glibc-only system libraries (`libudev`, `libsystemd`) that have no good musl story. The existing fallback `mod platform` in `src/transport/usb.rs` already covers the no-udev case as a stub for unsupported platforms (Windows, etc.), so musl Linux now falls into that same path — fine for the CPU backend and any non-USB hashboard.
- **Same `cfg` change in `src/tracing.rs`** so the journald init mod follows the same gate as its dependency.

Net diff: 4 files, +7 / -7 lines.

## Test plan

- [x] `cargo build --release` on macOS (aarch64-apple-darwin) — unchanged, still builds.
- [x] `cargo build --release --target aarch64-unknown-linux-musl --bin mujina-minerd` from macOS — now succeeds (previously failed at `openssl-sys` and `udev`).
- [x] Resulting 17 MB statically-linked aarch64 ELF transferred to an Antminer S19j Pro control board (LuxOS base, kernel aarch64 / userspace armhf — the static aarch64 binary runs fine via the 64-bit kernel).
- [x] `MUJINA_CPUMINER_THREADS=1 MUJINA_CPUMINER_DUTY=50 MUJINA_USB_DISABLE=1 MUJINA_API_LISTEN=0.0.0.0:7785 ./mujina-minerd` — comes up cleanly, CPU board attached, dummy job source, REST API responds at `/swagger-ui`, mining-status log line ticks at 30s.

## Build steps on macOS

```sh
rustup target add aarch64-unknown-linux-musl
brew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl

CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-unknown-linux-musl-gcc \
CC_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-gcc \
  cargo build --release --target aarch64-unknown-linux-musl --bin mujina-minerd
```

## Notes / open questions

- The `reqwest` rustls swap is mildly opinionated. If you'd prefer to keep `native-tls` as the default and offer rustls behind a feature flag instead, happy to refactor — but it'd add complexity for the cross-build path with no obvious upstream benefit.
- This is the minimal change to make the build *work*. Real S19 hashboard support (driving BM1362 chips over UART, APW12 PSU over I²C, fans, EEPROM decode, PIC sensor reads) is separate work — see [skot/amlogic-cb-tools](https://github.com/skot/amlogic-cb-tools) for the standalone hardware-validation binaries that prove out the control-board interfaces before they land in mujina.