### PR TITLE
cpu-miner: make the CPU backend a first-class citizen for API/tooling

### DIFF
--- a/mujina-miner/src/board/cpu.rs
+++ b/mujina-miner/src/board/cpu.rs
@@ -3,12 +3,14 @@
 //! Provides a virtual board that uses CPU cores for SHA-256 hashing.
 //! See [`CpuMinerConfig`] for environment variable configuration.
 
+use std::time::Duration;
+
 use anyhow::{Result, anyhow};
 use tokio::sync::watch;
 
 use super::{BackplaneConnector, BoardInfo, VirtualBoardDescriptor};
 use crate::{
-    api_client::types::BoardTelemetry,
+    api_client::types::{BoardTelemetry, ThreadTelemetry},
     asic::hash_thread::HashThread,
     cpu_miner::{CpuHashThread, CpuMinerConfig},
 };
@@ -34,27 +36,68 @@ async fn create_cpu_board() -> Result<BackplaneConnector> {
         )),
     };
 
+    let cpu_threads: Vec<CpuHashThread> = (0..config.thread_count)
+        .map(|i| CpuHashThread::new(format!("CPU Core {i}"), config.duty_percent))
+        .collect();
+
+    // Snapshot the thread names + live status handles before handing
+    // ownership of the threads to the scheduler. The board's telemetry
+    // task reads these to publish per-thread hashrate.
+    let thread_handles: Vec<(String, _)> = cpu_threads
+        .iter()
+        .map(|t| (t.name().to_string(), t.status_handle()))
+        .collect();
+
+    let initial_threads: Vec<ThreadTelemetry> = thread_handles
+        .iter()
+        .map(|(name, _)| ThreadTelemetry {
+            name: name.clone(),
+            hashrate: 0,
+            is_active: false,
+        })
+        .collect();
+
     let initial_state = BoardTelemetry {
         name: info.serial_number.clone().unwrap(),
         model: info.model.clone(),
         serial: info.serial_number.clone(),
+        threads: initial_threads,
         ..Default::default()
     };
-    let (_telemetry_tx, telemetry_rx) = watch::channel(initial_state);
+    let (telemetry_tx, telemetry_rx) = watch::channel(initial_state);
 
-    let threads: Vec<Box<dyn HashThread>> = (0..config.thread_count)
-        .map(|i| {
-            Box::new(CpuHashThread::new(
-                format!("CPU Core {i}"),
-                config.duty_percent,
-            )) as _
-        })
+    // Periodically refresh BoardTelemetry from each thread's status.
+    // The task owns telemetry_tx so the channel stays alive until the
+    // board is shut down; the registry then evicts the board normally.
+    let publisher = tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(2));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tick.tick().await;
+            let threads = thread_handles
+                .iter()
+                .map(|(name, status)| {
+                    let s = status.read().unwrap();
+                    ThreadTelemetry {
+                        name: name.clone(),
+                        hashrate: u64::from(s.hashrate),
+                        is_active: s.is_active,
+                    }
+                })
+                .collect();
+            telemetry_tx.send_modify(|t| t.threads = threads);
+        }
+    });
+
+    let threads: Vec<Box<dyn HashThread>> = cpu_threads
+        .into_iter()
+        .map(|t| Box::new(t) as Box<dyn HashThread>)
         .collect();
 
     Ok(BackplaneConnector {
         info,
         threads,
         telemetry_rx,
-        shutdown: None,
+        shutdown: Some(Box::pin(async move { publisher.abort() })),
     })
 }

--- a/mujina-miner/src/cpu_miner/thread.rs
+++ b/mujina-miner/src/cpu_miner/thread.rs
@@ -108,6 +108,15 @@ impl CpuHashThread {
         self.shutdown.store(true, Ordering::Relaxed);
         let _ = self.command_tx.send(MinerCommand::Shutdown);
     }
+
+    /// Clone of the live status handle.
+    ///
+    /// Lets the board layer publish per-thread telemetry without taking
+    /// ownership of the thread itself (which gets handed to the
+    /// scheduler).
+    pub fn status_handle(&self) -> Arc<RwLock<HashThreadStatus>> {
+        Arc::clone(&self.status)
+    }
 }
 
 impl Drop for CpuHashThread {

--- a/mujina-miner/src/scheduler.rs
+++ b/mujina-miner/src/scheduler.rs
@@ -201,28 +201,45 @@ impl Scheduler {
 
     /// Aggregate measured hashrate from per-thread estimators.
     ///
-    /// Returns the truth: zero if no shares have been recorded yet.
+    /// Falls back to the thread's self-reported `status().hashrate` when
+    /// the share-based estimator has no data yet. This surfaces a real
+    /// number for backends that measure hashrate directly (e.g. the CPU
+    /// miner, which counts hashes per cycle) without waiting for the
+    /// estimator to settle from observed shares -- which on slow
+    /// backends paired with a high source difficulty might never happen.
     fn measured_hashrate(&mut self) -> HashRate {
         self.threads
             .values_mut()
-            .map(|entry| entry.hashrate.hashrate())
+            .map(|entry| {
+                let estimated = entry.hashrate.hashrate();
+                if estimated.is_zero() {
+                    entry.thread.status().hashrate
+                } else {
+                    estimated
+                }
+            })
             .sum()
     }
 
     /// Aggregate hashrate for operational decisions.
     ///
-    /// Per thread, uses measured hashrate if the estimator has settled,
-    /// otherwise falls back to the static capability estimate. Suitable
-    /// for broadcasting to sources and difficulty warnings, where a zero
-    /// value at startup would be unhelpful.
+    /// Per thread, prefers the share-based estimator once settled, then
+    /// the thread's self-reported hashrate, then the static capability
+    /// estimate. Suitable for broadcasting to sources and difficulty
+    /// warnings, where a zero value at startup would be unhelpful.
     fn operational_hashrate(&mut self) -> HashRate {
         self.threads
             .values_mut()
             .map(|entry| {
-                entry
-                    .hashrate
-                    .settled_hashrate()
-                    .unwrap_or(entry.thread.capabilities().hashrate_estimate)
+                if let Some(settled) = entry.hashrate.settled_hashrate() {
+                    return settled;
+                }
+                let reported = entry.thread.status().hashrate;
+                if reported.is_zero() {
+                    entry.thread.capabilities().hashrate_estimate
+                } else {
+                    reported
+                }
             })
             .sum()
     }


### PR DESCRIPTION
## Summary

Three small, related changes that take the CPU mining backend from "runs and hashes" to "shows up correctly in the public API," so it's actually usable for exercising mujina end-to-end without ASIC hardware — developing against the REST API, testing UIs, prototyping integrations like exporters or message-bus bridges, etc.

- **`board/cpu.rs`** — keep the board's telemetry sender alive and publish per-thread telemetry from it.
  Previously the watch sender was bound to `_telemetry_tx` and dropped immediately on construction. `BoardRegistry::boards()` evicts any registration whose senders have all gone away, so the CPU board silently disappeared from `/api/v0/boards` (and from `MinerTelemetry.boards`) as soon as the registry was first queried. The board now snapshots each thread's status handle before handing the threads to the scheduler, then runs a small task that owns the sender and refreshes `BoardTelemetry.threads` from those handles every two seconds. Aborting the task on shutdown drops the sender, letting the registry clean up the board normally.

- **`cpu_miner/thread.rs`** — expose `status_handle()` so the board layer can read each thread's live `HashThreadStatus` (which the hasher already populates every five seconds with measured hashrate, share counts, etc.) without taking ownership of the thread itself. Ownership still goes to the scheduler.

- **`scheduler.rs`** — in `measured_hashrate()` and `operational_hashrate()`, fall back to `entry.thread.status().hashrate` when the share-based estimator has no settled value. The CPU backend measures hashrate directly from cycle counts, but at typical CPU rates against any reasonable source target it would essentially never produce shares fast enough for the estimator to settle, so the API field stayed at zero forever. ASIC backends that don't self-report keep falling through to the existing `capabilities().hashrate_estimate` constant exactly as before — this is purely an additional fallback, ordered *after* the truthful estimator and *before* the static guess.

## Why

The CPU backend exists in the tree for exactly the kind of work where you don't want to plug in (or own) real hashing hardware: developing against the API, testing the daemon end-to-end, and building tools that consume mujina's output. Today, even though the threads do hash, an API consumer sees \`{\"hashrate\": 0, \"boards\": []}\` indefinitely — which is indistinguishable from "nothing is running." That makes the CPU backend a poor base for any of those use cases. These changes close the gap so the API reflects what the backend is actually doing.

## Net effect

- On a CPU-only host: \`/api/v0/miner\` reports a non-zero aggregate \`hashrate\` within ~5s of startup, \`boards[0]\` shows up with per-thread \`hashrate\` and \`is_active\` populated.
- On ASIC hardware: behaviour is unchanged for boards whose threads don't write \`HashThreadStatus.hashrate\`. The new fallback in \`measured_hashrate()\` / \`operational_hashrate()\` only kicks in when both the share-based estimator is unsettled *and* the thread self-reports — neither condition holds for current ASIC backends.

## Test plan

- [x] \`cargo test -p mujina-miner --lib\` — existing scheduler and registry tests still pass.
- [x] Cross-built per #55 and deployed to an Antminer S19 control board (aarch64 musl):
  - Start: \`MUJINA_CPUMINER_THREADS=2 MUJINA_CPUMINER_DUTY=50 MUJINA_USB_DISABLE=1 MUJINA_API_LISTEN=0.0.0.0:7785 ./mujina-minerd\`
  - \`curl /api/v0/miner\` after ~12s:
    \`\`\`json
    {\"uptime_secs\":10,\"hashrate\":174652,\"shares_submitted\":0,\"paused\":false,
     \"boards\":[{\"name\":\"cpu-2x50%\",\"model\":\"CPU Miner\",\"serial\":\"cpu-2x50%\",
       \"fans\":[],\"temperatures\":[],\"powers\":[],
       \"threads\":[
         {\"name\":\"CPU Core 0\",\"hashrate\":89974,\"is_active\":true},
         {\"name\":\"CPU Core 1\",\"hashrate\":89964,\"is_active\":true}
       ]}],
     \"sources\":[{\"name\":\"dummy\",\"difficulty\":2328}]}
    \`\`\`
  - \`curl /api/v0/boards\` — previously \`[]\`, now lists the CPU board with the same per-thread detail.

## Notes

- Builds on top of #55 in spirit (same author, same hardware target), but doesn't depend on it — these changes work on glibc Linux too. Independent base for either merge order.