### PR TITLE
feat(transport): add native Windows support

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,305 @@
+# Windows Support for Mujina Miner
+
+This document explains how mujina-miner runs on Windows, the changes made for Windows compatibility, and setup instructions.
+
+## Overview
+
+Mujina-miner now has native Windows support, allowing direct communication with BitAxe miners through Windows COM ports without requiring WSL2 or Docker. This was achieved by implementing Windows-specific USB device discovery and serial port handling.
+
+## Architecture Changes
+
+### 1. USB Device Discovery
+
+**Original Implementation (Linux)**:
+- Used `libudev` for real-time USB hotplug events
+- Monitored `/sys/bus/usb/devices/*` filesystem
+
+**Windows Implementation**:
+- Uses `tokio_serial::available_ports()` for COM port enumeration
+- Polls for device changes every 2 seconds
+- Groups COM ports by USB device (VID:PID:SerialNumber)
+- File: [mujina-miner/src/transport/usb/windows.rs](mujina-miner/src/transport/usb/windows.rs)
+
+**Key Features**:
+- Detects USB CDC ACM devices automatically
+- Handles multi-port devices (BitAxe Gamma has 2 ports: control + data)
+- Tracks device connection/disconnection events
+- No external dependencies (uses built-in Windows APIs via tokio-serial)
+
+### 2. Serial Port Implementation
+
+**Original Implementation (Unix)**:
+- Used Unix file descriptors with `AsyncFd`
+- Direct access to `termios` for configuration
+
+**Windows Implementation**:
+- Uses `tokio_serial::SerialStream` (wraps Windows COM port APIs)
+- Provides identical API surface for cross-platform compatibility
+- File: [mujina-miner/src/transport/serial_windows.rs](mujina-miner/src/transport/serial_windows.rs)
+
+**Key Features**:
+- Async I/O using Tokio runtime
+- Runtime baud rate reconfiguration
+- Thread-safe with `RwLock` for shared access
+- Statistics tracking (bytes read/written)
+
+### 3. Signal Handling
+
+**Changes in [mujina-miner/src/daemon.rs](mujina-miner/src/daemon.rs)**:
+- Linux: Handles `SIGINT` and `SIGTERM`
+- Windows: Handles `Ctrl+C` via `tokio::signal::ctrl_c()`
+
+### 4. Board Pattern Matching
+
+**Changes in [mujina-miner/src/board/bitaxe.rs](mujina-miner/src/board/bitaxe.rs)**:
+- Changed from manufacturer/product string matching to VID:PID matching
+- Windows reports generic "Microsoft" manufacturer for CDC ACM devices
+- BitAxe devices identified by `VID:PID = c0de:cafe` (bitaxe-raw firmware)
+
+### 5. Async Board Initialization
+
+**Changes in [mujina-miner/src/board/bitaxe.rs](mujina-miner/src/board/bitaxe.rs)**:
+- Made `BitaxeBoard::new()` async to support async serial port opening
+- Prevents "runtime within runtime" errors when blocking on async operations
+
+## Platform-Specific Code Structure
+
+```
+mujina-miner/src/transport/
+├── usb.rs                    # Platform-agnostic USB transport
+├── usb/
+│   ├── linux.rs             # Linux udev implementation
+│   ├── windows.rs           # Windows COM port implementation (NEW)
+│   └── macos.rs             # macOS IOKit stub
+├── serial.rs                # Unix serial implementation
+└── serial_windows.rs        # Windows serial implementation (NEW)
+```
+
+Conditional compilation in [mujina-miner/src/transport/mod.rs](mujina-miner/src/transport/mod.rs):
+```rust
+#[cfg(not(target_os = "windows"))]
+pub mod serial;
+
+#[cfg(target_os = "windows")]
+#[path = "serial_windows.rs"]
+pub mod serial;
+```
+
+## Setup Instructions
+
+### Prerequisites
+
+1. **Rust Toolchain** (required)
+   - Download and install from https://rustup.rs
+   - Or use winget: `winget install Rustlang.Rustup`
+   - Verify installation: `rustc --version`
+
+2. **BitAxe Hardware** (with bitaxe-raw firmware)
+   - Should appear as two COM ports in Device Manager
+   - Example: COM11 (control) and COM7 (data)
+   - VID:PID should be `c0de:cafe`
+
+3. **Mining Pool** (optional for testing)
+   - Can run in dummy/test mode without pool connection
+   - For real mining, need Stratum v1 pool URL
+
+### Building from Source
+
+1. **Clone the repository** (if not already done):
+   ```powershell
+   git clone https://github.com/your-repo/mujina-miner.git
+   cd mujina-miner
+   ```
+
+2. **Build the project**:
+   ```powershell
+   cargo build --release
+   ```
+
+   This will compile the Windows-specific code automatically based on your platform.
+
+3. **Binary location**:
+   ```
+   target\release\mujina-minerd.exe
+   ```
+
+### Configuration
+
+Create a `.env` file in the project root (optional):
+
+```env
+# Mining pool configuration (optional - omit for dummy/test mode)
+MUJINA_POOL_URL=stratum+tcp://pool.example.com:3333
+MUJINA_POOL_USER=your-bitcoin-address.worker-name
+MUJINA_POOL_PASS=x
+
+# Logging level (optional)
+RUST_LOG=mujina_miner=info
+```
+
+For testing without a pool, simply omit `MUJINA_POOL_URL` and the miner will run in dummy mode.
+
+### Running
+
+**Basic run (dummy mode)**:
+```powershell
+.\target\release\mujina-minerd.exe
+```
+
+**With debug logging**:
+```powershell
+$env:RUST_LOG="mujina_miner=debug"
+.\target\release\mujina-minerd.exe
+```
+
+**With trace logging** (very verbose):
+```powershell
+$env:RUST_LOG="mujina_miner=trace"
+.\target\release\mujina-minerd.exe
+```
+
+### Expected Output
+
+On successful startup, you should see:
+```
+INFO daemon: Using dummy job source (set MUJINA_POOL_URL to use Stratum v1)
+INFO daemon: Started.
+INFO transport::usb::windows: Starting Windows COM port USB discovery
+DEBUG transport::usb::windows: Initial enumeration found 1 USB devices
+DEBUG transport::usb::windows: Found USB device: c0de:cafe:12345678 with ports: ["COM11", "COM7"]
+INFO board::bitaxe: BitAxe Gamma initialized successfully
+INFO board::bitaxe: EMC2101 fan controller initialized (speed: 100%)
+INFO board::bitaxe: TPS546 voltage regulator set to 1.15V
+INFO board::bitaxe: BM1370 chip discovered at address 0
+INFO scheduler: Hash thread registered
+INFO api: API server listening. url=http://127.0.0.1:7785
+```
+
+## Device Detection
+
+The miner automatically detects BitAxe devices by:
+
+1. **USB Enumeration**: Scans all COM ports for USB serial devices
+2. **VID:PID Matching**: Identifies BitAxe by `c0de:cafe` (bitaxe-raw firmware)
+3. **Port Grouping**: Groups multiple COM ports belonging to the same USB device
+4. **Board Creation**: Instantiates BitAxe Gamma board with control and data ports
+
+No manual port specification is required - the miner finds devices automatically.
+
+## Troubleshooting
+
+### Device Not Detected
+
+**Symptoms**: No "USB device connected" logs
+
+**Solutions**:
+1. Check Device Manager for COM ports with VID:PID `c0de:cafe`
+2. Ensure bitaxe-raw firmware is installed (not stock ESP32 firmware)
+3. Try unplugging and replugging the USB cable
+4. Run with `RUST_LOG=mujina_miner=debug` to see enumeration details
+
+### Access Denied on COM Ports
+
+**Symptoms**: `Serial port error: Access is denied. (os error 5)`
+
+**Solutions**:
+1. Close any other applications using the COM ports (Arduino IDE, PuTTY, etc.)
+2. Check if another mujina-minerd.exe instance is running
+3. Restart the device and wait 5 seconds before running mujina
+
+### Build Errors
+
+**Symptoms**: `failed to remove file mujina-minerd.exe: Access is denied`
+
+**Solutions**:
+1. Stop any running mujina-minerd.exe processes
+2. Close terminals/shells that may be locking the binary
+3. Use Task Manager to end the process if needed
+
+### Slow Hash Rate or No Shares
+
+**Symptoms**: Hash rate shows `--` or very low values
+
+**Solutions**:
+1. Check fan is spinning (EMC2101 should report 100%)
+2. Verify voltage regulator is set correctly (TPS546 should report ~1.15V)
+3. Check ASIC chip detection logs (should see "BM1370 chip discovered")
+4. Ensure sufficient USB power delivery (use powered USB hub if needed)
+
+## API Access
+
+The miner provides a REST API on `http://127.0.0.1:7785` for monitoring:
+
+- `/api/stats` - Mining statistics (hash rate, shares, uptime)
+- `/api/boards` - Connected board information
+- `/api/pools` - Pool connection status
+
+Access via browser, `curl`, or PowerShell:
+```powershell
+Invoke-WebRequest -Uri http://127.0.0.1:7785/api/stats | Select-Object -Expand Content
+```
+
+## Technical Details
+
+### Thread Safety
+
+Windows serial implementation uses:
+- `RwLock<TokioSerialStream>` for synchronized access
+- Atomic types for statistics counters
+- Safe interior mutability pattern
+
+Marked as `Send + Sync` with safety justification:
+```rust
+// SAFETY: SerialInner is Send because:
+// - TokioSerialStream is always accessed through RwLock
+// - All atomic fields are inherently Send
+unsafe impl Send for SerialInner {}
+
+// SAFETY: SerialInner is Sync because:
+// - All access to TokioSerialStream goes through RwLock
+// - Atomic fields are inherently Sync
+unsafe impl Sync for SerialInner {}
+```
+
+### Polling vs. Hotplug Events
+
+Unlike Linux's real-time udev events, Windows implementation uses polling (2-second interval). This is acceptable because:
+- USB device connection/disconnection is infrequent
+- 2-second detection latency is negligible for mining operations
+- Simpler implementation without Windows API hooks
+- Lower CPU overhead than continuous monitoring
+
+### COM Port Path Format
+
+Windows uses `COMx` format (e.g., `COM11`, `COM7`), while Linux uses `/dev/ttyACMx`. The serial implementation abstracts this difference, but internally:
+- Windows paths are passed directly to `tokio_serial`
+- Extended format `\\.\COMx` used automatically for ports > COM9
+
+## Contributing
+
+When making changes that affect Windows support:
+
+1. Test on Windows with actual BitAxe hardware
+2. Ensure conditional compilation remains correct (`#[cfg(target_os = "windows")]`)
+3. Maintain API parity between Unix and Windows implementations
+4. Update this documentation if adding Windows-specific features
+
+## Known Limitations
+
+1. **Polling-based detection**: 2-second latency for new device detection (vs. instant on Linux)
+2. **No Windows Device Manager integration**: Changes in Device Manager require application restart
+3. **COM port numbering**: High COM port numbers (>256) may require special handling
+
+## Files Modified for Windows Support
+
+Core changes:
+- [mujina-miner/src/transport/usb/windows.rs](mujina-miner/src/transport/usb/windows.rs) - Windows USB discovery (NEW)
+- [mujina-miner/src/transport/serial_windows.rs](mujina-miner/src/transport/serial_windows.rs) - Windows serial implementation (NEW)
+- [mujina-miner/src/transport/usb.rs](mujina-miner/src/transport/usb.rs) - Platform abstraction and Clone impl
+- [mujina-miner/src/transport/mod.rs](mujina-miner/src/transport/mod.rs) - Conditional compilation
+- [mujina-miner/src/board/bitaxe.rs](mujina-miner/src/board/bitaxe.rs) - VID:PID matching, async init
+- [mujina-miner/src/daemon.rs](mujina-miner/src/daemon.rs) - Windows signal handling
+
+## License
+
+Same as the main project.

--- a/mujina-miner/src/board/bitaxe.rs
+++ b/mujina-miner/src/board/bitaxe.rs
@@ -143,7 +143,8 @@ pub struct BitaxeBoard {
 }
 
 impl BitaxeBoard {
-    /// GPIO pin number for ASIC reset control (active low)
+    /// GPIO command for ASIC reset control (active low)
+    /// bitaxe-raw firmware uses command 0x00 for ASIC reset (not a GPIO pin number)
     const ASIC_RESET_PIN: u8 = 0;
 
     /// Bitaxe Gamma board configuration
@@ -166,7 +167,7 @@ impl BitaxeBoard {
     /// # Design Note
     /// In the future, a DeviceManager will create boards when USB devices
     /// are detected (by VID/PID) and pass already-opened serial streams.
-    pub fn new(
+    pub async fn new(
         control: tokio_serial::SerialStream,
         data_path: &str,
         serial_number: Option<String>,
@@ -176,7 +177,11 @@ impl BitaxeBoard {
         let i2c = BitaxeRawI2c::new(control_channel.clone());
 
         // Create SerialStream for data channel at initial baud rate
-        let data_stream = SerialStream::new(data_path, 115200).map_err(|e| {
+        let config = crate::transport::SerialConfig {
+            baud_rate: 115200,
+            ..Default::default()
+        };
+        let data_stream = SerialStream::open(data_path, config).await.map_err(|e| {
             BoardError::InitializationFailed(format!("Failed to open data port: {}", e))
         })?;
         let (data_reader, data_writer, data_control) = data_stream.split();
@@ -467,6 +472,26 @@ impl BitaxeBoard {
                 match fan.set_fan_speed(Percent::FULL).await {
                     Ok(()) => {
                         debug!("Fan speed set to 100%");
+
+                        // Wait for fan to spin up
+                        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+                        // Read back and verify RPM
+                        match fan.get_rpm().await {
+                            Ok(rpm) => {
+                                info!("Fan RPM after initialization: {}", rpm);
+                                if rpm < 500 {
+                                    warn!("Fan RPM is suspiciously low! Check EMC2101 configuration");
+                                } else if rpm > 10000 {
+                                    warn!("Fan RPM is suspiciously high! Check EMC2101 configuration");
+                                } else {
+                                    info!("Fan RPM is within normal range");
+                                }
+                            }
+                            Err(e) => {
+                                warn!("Failed to read fan RPM: {}", e);
+                            }
+                        }
                     }
                     Err(e) => {
                         warn!("Failed to set fan speed: {}", e);
@@ -932,14 +957,15 @@ async fn create_from_usb(
         serial = ?device.serial_number,
         control = %serial_ports[0],
         data = %serial_ports[1],
-        "Opening Bitaxe Gamma serial ports"
+        "Opening Bitaxe Gamma serial ports (per bitaxe-raw source: interface 0=control, 1=data)"
     );
 
-    // Open control port at 115200 baud
+    // Open control port at 115200 baud (ttyACM0 = control per bitaxe-raw firmware)
     let control_port = tokio_serial::new(&serial_ports[0], 115200).open_native_async()?;
 
-    // Create the board with the control port and data port path
+    // Create the board with the control port and data port path (ttyACM1 = data per bitaxe-raw firmware)
     let mut board = BitaxeBoard::new(control_port, &serial_ports[1], device.serial_number.clone())
+        .await
         .map_err(|e| crate::error::Error::Hardware(format!("Failed to create board: {}", e)))?;
 
     // Initialize the board (reset, discover chips, start event monitoring)
@@ -960,10 +986,12 @@ async fn create_from_usb(
 inventory::submit! {
     crate::board::BoardDescriptor {
         pattern: crate::board::pattern::BoardPattern {
-            vid: Match::Any,
-            pid: Match::Any,
-            manufacturer: Match::Specific(StringMatch::Exact("OSMU")),
-            product: Match::Specific(StringMatch::Exact("Bitaxe")),
+            // Match BitAxe by VID:PID (c0de:cafe for bitaxe-raw firmware)
+            // Windows reports generic "Microsoft" manufacturer instead of actual device strings
+            vid: Match::Specific(0xc0de),
+            pid: Match::Specific(0xcafe),
+            manufacturer: Match::Any,
+            product: Match::Any,
             serial_pattern: Match::Any,
         },
         name: "Bitaxe Gamma",

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -3,6 +3,7 @@
 //! This module handles the core daemon functionality including initialization,
 //! task management, signal handling, and graceful shutdown.
 
+#[cfg(unix)]
 use tokio::signal::unix::{self, SignalKind};
 use tokio::sync::mpsc;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -155,18 +156,28 @@ impl Daemon {
         info!("Started.");
         info!("For debugging, set RUST_LOG=mujina_miner=debug or trace.");
 
-        // Install signal handlers
-        let mut sigint = unix::signal(SignalKind::interrupt())?;
-        let mut sigterm = unix::signal(SignalKind::terminate())?;
+        // Wait for shutdown signal (platform-specific)
+        #[cfg(unix)]
+        {
+            // Install Unix signal handlers
+            let mut sigint = unix::signal(SignalKind::interrupt())?;
+            let mut sigterm = unix::signal(SignalKind::terminate())?;
 
-        // Wait for shutdown signal
-        tokio::select! {
-            _ = sigint.recv() => {
-                info!("Received SIGINT.");
-            },
-            _ = sigterm.recv() => {
-                info!("Received SIGTERM.");
-            },
+            tokio::select! {
+                _ = sigint.recv() => {
+                    info!("Received SIGINT.");
+                },
+                _ = sigterm.recv() => {
+                    info!("Received SIGTERM.");
+                },
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            // Use Ctrl+C handler on Windows
+            tokio::signal::ctrl_c().await?;
+            info!("Received Ctrl+C.");
         }
 
         // Initiate shutdown

--- a/mujina-miner/src/transport/mod.rs
+++ b/mujina-miner/src/transport/mod.rs
@@ -5,7 +5,13 @@
 //! implementation provides device discovery and emits transport-specific
 //! events when devices are connected or disconnected.
 
+#[cfg(not(target_os = "windows"))]
 pub mod serial;
+
+#[cfg(target_os = "windows")]
+#[path = "serial_windows.rs"]
+pub mod serial;
+
 pub mod usb;
 
 // Re-export transport implementations

--- a/mujina-miner/src/transport/serial_windows.rs
+++ b/mujina-miner/src/transport/serial_windows.rs
@@ -1,0 +1,333 @@
+//! Windows serial stream implementation using tokio-serial.
+//!
+//! This provides a Windows-compatible version of SerialStream that matches
+//! the Unix implementation's API but uses tokio-serial internally.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_serial::{SerialPort, SerialPortBuilderExt, SerialStream as TokioSerialStream};
+
+/// Parity configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Parity {
+    None = 0,
+    Odd = 1,
+    Even = 2,
+}
+
+impl From<Parity> for tokio_serial::Parity {
+    fn from(p: Parity) -> Self {
+        match p {
+            Parity::None => tokio_serial::Parity::None,
+            Parity::Odd => tokio_serial::Parity::Odd,
+            Parity::Even => tokio_serial::Parity::Even,
+        }
+    }
+}
+
+impl From<tokio_serial::Parity> for Parity {
+    fn from(p: tokio_serial::Parity) -> Self {
+        match p {
+            tokio_serial::Parity::None => Parity::None,
+            tokio_serial::Parity::Odd => Parity::Odd,
+            tokio_serial::Parity::Even => Parity::Even,
+        }
+    }
+}
+
+/// Serial port configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct SerialConfig {
+    pub baud_rate: u32,
+    pub data_bits: u8,
+    pub stop_bits: u8,
+    pub parity: Parity,
+}
+
+impl Default for SerialConfig {
+    fn default() -> Self {
+        Self {
+            baud_rate: 115200,
+            data_bits: 8,
+            stop_bits: 1,
+            parity: Parity::None,
+        }
+    }
+}
+
+/// Serial port error types.
+#[derive(Debug, thiserror::Error)]
+pub enum SerialError {
+    #[error("Failed to open serial port: {0}")]
+    OpenError(#[source] io::Error),
+
+    #[error("Unsupported baud rate: {0}")]
+    UnsupportedBaudRate(u32),
+
+    #[error("Configuration failed: {0}")]
+    ConfigError(String),
+
+    #[error("I/O error: {0}")]
+    IoError(#[from] io::Error),
+
+    #[error("Serial port disconnected")]
+    Disconnected,
+
+    #[error("Hardware error on serial port")]
+    HardwareError,
+
+    #[error("Operation timed out")]
+    Timeout,
+}
+
+/// Statistics for a serial port.
+#[derive(Debug, Clone, Copy)]
+pub struct SerialStats {
+    /// Total bytes read from the port.
+    pub bytes_read: u64,
+    /// Total bytes written to the port.
+    pub bytes_written: u64,
+    /// Current baud rate.
+    pub baud_rate: u32,
+}
+
+/// A serial stream implementation that supports runtime reconfiguration.
+pub struct SerialStream {
+    inner: Arc<SerialInner>,
+}
+
+struct SerialInner {
+    /// The underlying tokio-serial stream
+    stream: RwLock<TokioSerialStream>,
+
+    /// Current configuration - atomic for lock-free reads
+    baud_rate: AtomicU32,
+    data_bits: AtomicU8,
+    stop_bits: AtomicU8,
+    parity: AtomicU8, // 0 = None, 1 = Odd, 2 = Even
+
+    /// Lock for reconfiguration
+    reconfig_lock: RwLock<()>,
+
+    /// Statistics (lock-free)
+    bytes_read: AtomicU64,
+    bytes_written: AtomicU64,
+}
+
+// SAFETY: SerialInner is Send because:
+// - The TokioSerialStream is always accessed through an RwLock, which provides proper synchronization
+// - All atomic fields are inherently Send
+// - We never expose raw pointers or unsynchronized mutable access
+unsafe impl Send for SerialInner {}
+
+// SAFETY: SerialInner is Sync because:
+// - All access to the TokioSerialStream goes through RwLock, preventing concurrent mutations
+// - Atomic fields are inherently Sync
+// - The RwLock<()> for reconfiguration ensures exclusive access during config changes
+unsafe impl Sync for SerialInner {}
+
+/// Reader half of a split serial stream.
+pub struct SerialReader {
+    inner: Arc<SerialInner>,
+}
+
+/// Writer half of a split serial stream.
+pub struct SerialWriter {
+    inner: Arc<SerialInner>,
+}
+
+/// Control handle for a split serial stream.
+pub struct SerialControl {
+    inner: Arc<SerialInner>,
+}
+
+impl SerialStream {
+    /// Open a new serial port with the specified baud rate.
+    ///
+    /// Uses default configuration of 8N1 (8 data bits, no parity, 1 stop bit).
+    /// This is a blocking wrapper around the async `open()` method for API compatibility.
+    pub fn new(path: &str, baud_rate: u32) -> Result<Self, SerialError> {
+        let config = SerialConfig {
+            baud_rate,
+            ..Default::default()
+        };
+        // Block on the async open
+        tokio::runtime::Handle::current().block_on(Self::open(path, config))
+    }
+
+    /// Open a serial port with the specified configuration (async version).
+    pub async fn open(path: &str, config: SerialConfig) -> Result<Self, SerialError> {
+        // Build the serial port
+        let stream = tokio_serial::new(path, config.baud_rate)
+            .data_bits(match config.data_bits {
+                5 => tokio_serial::DataBits::Five,
+                6 => tokio_serial::DataBits::Six,
+                7 => tokio_serial::DataBits::Seven,
+                8 => tokio_serial::DataBits::Eight,
+                _ => return Err(SerialError::ConfigError(format!("Invalid data bits: {}", config.data_bits))),
+            })
+            .stop_bits(match config.stop_bits {
+                1 => tokio_serial::StopBits::One,
+                2 => tokio_serial::StopBits::Two,
+                _ => return Err(SerialError::ConfigError(format!("Invalid stop bits: {}", config.stop_bits))),
+            })
+            .parity(config.parity.into())
+            .timeout(Duration::from_millis(100))
+            .open_native_async()
+            .map_err(|e| SerialError::ConfigError(format!("Failed to open serial port: {}", e)))?;
+
+        let inner = SerialInner {
+            stream: RwLock::new(stream),
+            baud_rate: AtomicU32::new(config.baud_rate),
+            data_bits: AtomicU8::new(config.data_bits),
+            stop_bits: AtomicU8::new(config.stop_bits),
+            parity: AtomicU8::new(config.parity as u8),
+            reconfig_lock: RwLock::new(()),
+            bytes_read: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
+        };
+
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    /// Split the stream into reader, writer, and control handles.
+    pub fn split(self) -> (SerialReader, SerialWriter, SerialControl) {
+        (
+            SerialReader {
+                inner: Arc::clone(&self.inner),
+            },
+            SerialWriter {
+                inner: Arc::clone(&self.inner),
+            },
+            SerialControl {
+                inner: self.inner,
+            },
+        )
+    }
+
+    /// Get current statistics.
+    pub fn stats(&self) -> SerialStats {
+        SerialStats {
+            bytes_read: self.inner.bytes_read.load(Ordering::Relaxed),
+            bytes_written: self.inner.bytes_written.load(Ordering::Relaxed),
+            baud_rate: self.inner.baud_rate.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl AsyncRead for SerialStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let mut stream = self.inner.stream.write();
+        let result = Pin::new(&mut *stream).poll_read(cx, buf);
+        let bytes_read = buf.filled().len() - before;
+        self.inner.bytes_read.fetch_add(bytes_read as u64, Ordering::Relaxed);
+        result
+    }
+}
+
+impl AsyncWrite for SerialStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut stream = self.inner.stream.write();
+        let result = Pin::new(&mut *stream).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &result {
+            self.inner.bytes_written.fetch_add(*n as u64, Ordering::Relaxed);
+        }
+        result
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut stream = self.inner.stream.write();
+        Pin::new(&mut *stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut stream = self.inner.stream.write();
+        Pin::new(&mut *stream).poll_shutdown(cx)
+    }
+}
+
+impl AsyncRead for SerialReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let mut stream = self.inner.stream.write();
+        let result = Pin::new(&mut *stream).poll_read(cx, buf);
+        let bytes_read = buf.filled().len() - before;
+        self.inner.bytes_read.fetch_add(bytes_read as u64, Ordering::Relaxed);
+        result
+    }
+}
+
+impl AsyncWrite for SerialWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut stream = self.inner.stream.write();
+        let result = Pin::new(&mut *stream).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &result {
+            self.inner.bytes_written.fetch_add(*n as u64, Ordering::Relaxed);
+        }
+        result
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut stream = self.inner.stream.write();
+        Pin::new(&mut *stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut stream = self.inner.stream.write();
+        Pin::new(&mut *stream).poll_shutdown(cx)
+    }
+}
+
+impl SerialControl {
+    /// Change the baud rate at runtime.
+    pub async fn set_baud_rate(&self, baud_rate: u32) -> Result<(), SerialError> {
+        let _guard = self.inner.reconfig_lock.write();
+
+        let mut stream = self.inner.stream.write();
+        stream.set_baud_rate(baud_rate)
+            .map_err(|e| SerialError::ConfigError(format!("Failed to set baud rate: {}", e)))?;
+
+        self.inner.baud_rate.store(baud_rate, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Get current baud rate.
+    pub fn baud_rate(&self) -> u32 {
+        self.inner.baud_rate.load(Ordering::Relaxed)
+    }
+
+    /// Get current statistics.
+    pub fn stats(&self) -> SerialStats {
+        SerialStats {
+            bytes_read: self.inner.bytes_read.load(Ordering::Relaxed),
+            bytes_written: self.inner.bytes_written.load(Ordering::Relaxed),
+            baud_rate: self.inner.baud_rate.load(Ordering::Relaxed),
+        }
+    }
+}

--- a/mujina-miner/src/transport/usb.rs
+++ b/mujina-miner/src/transport/usb.rs
@@ -8,6 +8,7 @@
 //!
 //! - **Linux**: Uses udev for device enumeration and hotplug monitoring
 //! - **macOS**: Stub implementation (IOKit support planned for future)
+//! - **Windows**: Uses serialport crate for COM port enumeration with polling
 
 use crate::{error::Result, tracing::prelude::*};
 use std::sync::OnceLock;
@@ -36,6 +37,28 @@ pub struct UsbDeviceInfo {
     // Future: other interfaces like HID, mass storage, etc.
 }
 
+impl Clone for UsbDeviceInfo {
+    fn clone(&self) -> Self {
+        // Clone serial ports only if successful - errors cannot be cloned
+        let ports_clone = if let Some(Ok(ports)) = self.serial_ports.get() {
+            OnceLock::from(Ok(ports.clone()))
+        } else {
+            // If error or not cached, leave empty (will re-scan on access)
+            OnceLock::new()
+        };
+
+        Self {
+            vid: self.vid,
+            pid: self.pid,
+            serial_number: self.serial_number.clone(),
+            manufacturer: self.manufacturer.clone(),
+            product: self.product.clone(),
+            device_path: self.device_path.clone(),
+            serial_ports: ports_clone,
+        }
+    }
+}
+
 impl UsbDeviceInfo {
     /// Get serial ports associated with this USB device.
     ///
@@ -52,7 +75,11 @@ impl UsbDeviceInfo {
                 {
                     linux::find_serial_ports_for_device(&self.device_path)
                 }
-                #[cfg(not(target_os = "linux"))]
+                #[cfg(target_os = "windows")]
+                {
+                    windows::find_serial_ports_for_device(&self.device_path)
+                }
+                #[cfg(not(any(target_os = "linux", target_os = "windows")))]
                 {
                     Ok(vec![])
                 }
@@ -164,6 +191,9 @@ mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
 
+#[cfg(target_os = "windows")]
+mod windows;
+
 /// Internal trait for platform-specific USB discovery implementations.
 ///
 /// This trait is not exposed publicly - only `UsbTransport` uses it internally.
@@ -212,7 +242,12 @@ fn create_discovery() -> Result<Box<dyn UsbDiscoveryImpl>> {
         Ok(Box::new(macos::MacOsIoKitDiscovery::new()?))
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(target_os = "windows")]
+    {
+        Ok(Box::new(windows::WindowsSerialDiscovery::new()?))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         compile_error!("USB discovery is not implemented for this platform");
     }

--- a/mujina-miner/src/transport/usb/windows.rs
+++ b/mujina-miner/src/transport/usb/windows.rs
@@ -1,0 +1,221 @@
+//! Windows COM port-based USB discovery implementation.
+//!
+//! This module discovers USB devices on Windows using the serialport crate's
+//! cross-platform port enumeration API.
+//!
+//! ## Architecture
+//!
+//! USB monitoring runs in a dedicated OS thread since we use blocking I/O
+//! for port enumeration. This matches the pattern used on Linux but adapts
+//! for Windows COM ports instead of udev.
+//!
+//! ## Device Discovery
+//!
+//! The implementation uses serialport to:
+//! - Enumerate existing COM ports at startup
+//! - Extract VID/PID/serial number from port information
+//! - Group ports by parent USB device (using VID/PID/serial)
+//! - Emit events for discovered devices
+//!
+//! ## Limitations
+//!
+//! Unlike Linux's udev which provides real-time hotplug events, this Windows
+//! implementation performs periodic polling. This is a reasonable trade-off
+//! for now, as device connection/disconnection is relatively infrequent.
+
+use super::{TransportEvent as UsbEvent, UsbDeviceInfo};
+use crate::{error::Result, tracing::prelude::*, transport::TransportEvent};
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tokio_serial::SerialPortType;
+
+/// Windows USB discovery implementation using COM port enumeration.
+pub struct WindowsSerialDiscovery {
+    // No state needed - we'll enumerate ports on each poll
+}
+
+impl WindowsSerialDiscovery {
+    /// Create a new Windows serial discovery implementation.
+    pub fn new() -> Result<Self> {
+        Ok(Self {})
+    }
+}
+
+impl super::UsbDiscoveryImpl for WindowsSerialDiscovery {
+    fn monitor_blocking(
+        self: Box<Self>,
+        event_tx: mpsc::Sender<super::super::TransportEvent>,
+        shutdown: CancellationToken,
+    ) -> Result<()> {
+        info!("Starting Windows COM port USB discovery");
+
+        // Track known devices by a unique key (VID:PID:SERIAL)
+        let mut known_devices: HashMap<String, Vec<String>> = HashMap::new();
+
+        // Initial enumeration
+        match enumerate_usb_devices() {
+            Ok(devices) => {
+                debug!("Initial enumeration found {} USB devices", devices.len());
+                for (device_key, device_info, ports) in devices {
+                    debug!("Found USB device: {} with ports: {:?}", device_key, ports);
+                    debug!(
+                        "  VID:PID = {:04x}:{:04x}, Manufacturer: {:?}, Product: {:?}",
+                        device_info.vid,
+                        device_info.pid,
+                        device_info.manufacturer,
+                        device_info.product
+                    );
+                    known_devices.insert(device_key, ports.clone());
+                    let event = TransportEvent::Usb(UsbEvent::UsbDeviceConnected(device_info));
+                    if event_tx.blocking_send(event).is_err() {
+                        info!("USB event channel closed, shutting down");
+                        return Ok(());
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Initial port enumeration failed: {}", e);
+            }
+        }
+
+        // Poll for changes every 2 seconds
+        let poll_interval = Duration::from_secs(2);
+
+        loop {
+            // Check for shutdown
+            if shutdown.is_cancelled() {
+                info!("USB monitor shutting down");
+                break;
+            }
+
+            // Sleep for poll interval (check shutdown periodically)
+            std::thread::sleep(poll_interval);
+
+            // Enumerate again and compare
+            match enumerate_usb_devices() {
+                Ok(current_devices) => {
+                    let current_keys: HashSet<_> =
+                        current_devices.iter().map(|(k, _, _)| k.clone()).collect();
+                    let known_keys: HashSet<_> = known_devices.keys().cloned().collect();
+
+                    // Find new devices (in current but not in known)
+                    for device_key in current_keys.difference(&known_keys) {
+                        if let Some((_, device_info, ports)) = current_devices
+                            .iter()
+                            .find(|(k, _, _)| k == device_key)
+                        {
+                            debug!("New USB device detected: {}", device_key);
+                            known_devices.insert(device_key.clone(), ports.clone());
+                            let event =
+                                TransportEvent::Usb(UsbEvent::UsbDeviceConnected(device_info.clone()));
+                            if event_tx.blocking_send(event).is_err() {
+                                info!("USB event channel closed, shutting down");
+                                return Ok(());
+                            }
+                        }
+                    }
+
+                    // Find removed devices (in known but not in current)
+                    for device_key in known_keys.difference(&current_keys) {
+                        debug!("USB device disconnected: {}", device_key);
+                        // Remove from tracking
+                        known_devices.remove(device_key);
+                        // Send disconnect event (use device_key as device_path)
+                        let event = TransportEvent::Usb(UsbEvent::UsbDeviceDisconnected {
+                            device_path: device_key.clone(),
+                        });
+                        if event_tx.blocking_send(event).is_err() {
+                            info!("USB event channel closed, shutting down");
+                            return Ok(());
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Port enumeration failed: {}", e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Enumerate USB devices by discovering COM ports.
+///
+/// Returns a vector of (device_key, UsbDeviceInfo, port_names) tuples.
+/// The device_key is a unique identifier like "c0de:cafe:12345678".
+fn enumerate_usb_devices() -> Result<Vec<(String, UsbDeviceInfo, Vec<String>)>> {
+    // Use tokio_serial to enumerate all available ports
+    let ports = tokio_serial::available_ports()
+        .map_err(|e| crate::error::Error::Other(format!("Failed to enumerate COM ports: {}", e)))?;
+
+    // Group ports by USB device (VID:PID:serial)
+    let mut device_map: HashMap<String, (tokio_serial::UsbPortInfo, Vec<String>)> = HashMap::new();
+
+    for port in ports {
+        // Only process USB serial ports (not native COM ports or Bluetooth)
+        if let SerialPortType::UsbPort(usb_info) = &port.port_type {
+            // Create a unique key for this USB device
+            let device_key = format!(
+                "{:04x}:{:04x}:{}",
+                usb_info.vid,
+                usb_info.pid,
+                usb_info
+                    .serial_number
+                    .as_deref()
+                    .unwrap_or("no-serial")
+            );
+
+            // Add this port to the device's port list
+            device_map
+                .entry(device_key)
+                .or_insert_with(|| (usb_info.clone(), Vec::new()))
+                .1
+                .push(port.port_name.clone());
+        }
+    }
+
+    // Convert to result format
+    let mut devices = Vec::new();
+    for (device_key, (usb_info, mut ports)) in device_map {
+        // Sort ports for consistent ordering (COM3 before COM11)
+        ports.sort();
+
+        // Create UsbDeviceInfo
+        let device_info = create_device_info(usb_info, device_key.clone(), ports.clone());
+        devices.push((device_key, device_info, ports));
+    }
+
+    Ok(devices)
+}
+
+/// Create a UsbDeviceInfo from Windows USB port information.
+fn create_device_info(
+    usb_info: tokio_serial::UsbPortInfo,
+    device_path: String,
+    ports: Vec<String>,
+) -> UsbDeviceInfo {
+    UsbDeviceInfo {
+        vid: usb_info.vid,
+        pid: usb_info.pid,
+        serial_number: usb_info.serial_number.clone(),
+        manufacturer: usb_info.manufacturer.clone(),
+        product: usb_info.product.clone(),
+        device_path,
+        serial_ports: OnceLock::from(Ok(ports)),
+    }
+}
+
+/// Find serial ports for a device (Windows implementation).
+///
+/// On Windows, we already cached the ports in UsbDeviceInfo during enumeration,
+/// so this function is just for API compatibility.
+pub(super) fn find_serial_ports_for_device(_device_path: &str) -> Result<Vec<String>> {
+    // On Windows, serial ports are already cached in UsbDeviceInfo
+    // This function exists for API compatibility but shouldn't be called
+    // since we populate serial_ports during device creation
+    Ok(vec![])
+}


### PR DESCRIPTION
## Summary

- **Windows USB discovery**: polls COM ports every 2s via `tokio_serial::available_ports()`, groups by VID:PID:serial, emits the same `UsbDeviceConnected`/`UsbDeviceDisconnected` events as the Linux udev path
- **Windows serial I/O**: `serial_windows.rs` wraps `tokio-serial` with async read/write, runtime baud rate changes, split reader/writer/control handles — identical API surface to the Unix implementation
- **Signal handling**: replaces `SIGINT`/`SIGTERM` with `tokio::signal::ctrl_c()` on Windows
- **Board matching**: switched from manufacturer/product string matching to VID:PID (`c0de:cafe`) — Windows reports "Microsoft" as manufacturer for CDC ACM devices instead of "OSMU"/"Bitaxe"
- **Async init**: `BitaxeBoard::new()` is now `async` to avoid "runtime within runtime" panics when opening the data port on Windows
- **Docs**: `WINDOWS.md` covers setup, architecture, troubleshooting, and known limitations

## Platform notes

Tested on Windows 11 with a BitAxe Gamma running bitaxe-raw firmware. No WSL2 or Docker required — runs as a native `.exe`.

Detection latency is ~2s on Windows (polling) vs near-instant on Linux (udev netlink). This is acceptable for mining use.

## Test plan

- [ ] Build on Windows: `cargo build --release`
- [ ] Plug in a BitAxe Gamma (bitaxe-raw firmware, VID:PID `c0de:cafe`) and confirm it appears in logs within 2s
- [ ] Unplug and confirm disconnect event is logged
- [ ] Confirm Linux build is unaffected (`cargo build` on Linux)
- [ ] Confirm `cargo check --target x86_64-unknown-linux-gnu` passes from Windows (cross-check)

## Files changed

| File | Change |
|------|--------|
| `transport/usb/windows.rs` | NEW — COM port polling discovery |
| `transport/serial_windows.rs` | NEW — async serial I/O via tokio-serial |
| `transport/mod.rs` | conditional compilation for Windows serial |
| `transport/usb.rs` | Clone impl, Windows platform wiring |
| `daemon.rs` | Windows Ctrl+C signal handling |
| `board/bitaxe.rs` | VID:PID matching, async new(), fan diagnostics |
| `WINDOWS.md` | setup and architecture docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)