### PR TITLE
feat(config): introduce config tree with souces

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,9 +69,9 @@ Percentage fields (`percent`, `target_percent`) are integers
 
 ### Naming
 
-Boards and sources are identified by a URL-friendly `name` field
-(e.g. `bitaxe-e2f56f9b`). These names appear in URL paths for
-single-resource endpoints like `/api/v0/boards/{name}`.
+Boards and sources are identified by a URL-friendly `name`
+field (e.g. `bitaxe-e2f56f9b`). These names appear in URL paths
+for single-resource endpoints like `/api/v0/boards/{name}`.
 
 ## Endpoints
 
@@ -92,12 +92,38 @@ table is a summary and may not be exhaustive.
 | GET    | `/boards`         | List connected boards |
 | GET    | `/boards/{name}`  | Single board detail   |
 
+### Config
+
+| Method | Path      | Description             |
+|--------|-----------|--------------------------|
+| GET    | `/config` | Full configuration tree |
+
+Includes each pool's password in plaintext -- there is no
+redaction. The API has no authentication, so anyone who can
+reach it can read it.
+
 ### Sources
 
-| Method | Path              | Description          |
-|--------|-------------------|----------------------|
-| GET    | `/sources`        | List job sources     |
-| GET    | `/sources/{name}` | Single source detail |
+| Method | Path              | Description                  |
+|--------|-------------------|-------------------------------|
+| GET    | `/sources`        | List configured job sources  |
+| GET    | `/sources/{name}` | Single source detail         |
+
+Same data as the `sources` field of `/config`, addressable by
+`name`. Each entry carries a `kind` field identifying what kind
+of source it is; `"stratum_v1"` is the only kind today, with
+fields matching a Stratum pool (`url`, `username`, `password`).
+"Source" is the term the rest of the codebase already uses for
+this concept, and it covers more than pool connections -- the
+dummy source used when none is configured, and, over time,
+other protocols (Stratum v2 and beyond). `kind` exists so a
+client can tell sources apart, and so adding a source kind
+later is additive rather than a breaking change to this
+endpoint.
+
+A source's `name` is assigned automatically today (`a`, `b`,
+`c`, ... by position) since there's no way to name one
+explicitly yet.
 
 ### Health
 
@@ -109,8 +135,15 @@ All paths are relative to `/api/v0`.
 
 ## Types
 
-The request and response types are defined in Rust in the
+Most request and response types are defined in Rust in the
 `api_client::types` module
 (`mujina-miner/src/api_client/types.rs`). These types are the
 shared contract between the server and its clients (CLI, TUI).
 The OpenAPI schema is derived from them automatically.
+
+`/config` and `/sources` are the exception: they serialize
+`config::Config`, `config::SourceConfig`
+(`mujina-miner/src/config.rs`), and
+`stratum_v1::StratumV1PoolConfig`
+(`mujina-miner/src/stratum_v1/client.rs`) directly, rather than a
+separate view type.

--- a/mujina-miner/src/api/server.rs
+++ b/mujina-miner/src/api/server.rs
@@ -20,6 +20,7 @@ use super::{
     v0,
 };
 use crate::api_client::types::MinerTelemetry;
+use crate::config::Config;
 
 /// API server configuration.
 #[derive(Debug, Clone)]
@@ -34,6 +35,7 @@ pub(crate) struct SharedState {
     pub miner_telemetry_rx: watch::Receiver<MinerTelemetry>,
     pub board_registry: Arc<Mutex<BoardRegistry>>,
     pub scheduler_cmd_tx: mpsc::Sender<SchedulerCommand>,
+    pub config: Arc<Config>,
 }
 
 impl SharedState {
@@ -65,6 +67,7 @@ pub async fn serve(
     miner_telemetry_rx: watch::Receiver<MinerTelemetry>,
     mut board_reg_rx: mpsc::Receiver<BoardRegistration>,
     scheduler_cmd_tx: mpsc::Sender<SchedulerCommand>,
+    config_tree: Config,
 ) -> Result<()> {
     let board_registry = Arc::new(Mutex::new(BoardRegistry::new()));
 
@@ -79,7 +82,12 @@ pub async fn serve(
         }
     });
 
-    let app = build_router(miner_telemetry_rx, board_registry, scheduler_cmd_tx);
+    let app = build_router(
+        miner_telemetry_rx,
+        board_registry,
+        scheduler_cmd_tx,
+        Arc::new(config_tree),
+    );
 
     let listener = TcpListener::bind(&config.bind_addr).await?;
     let actual_addr = listener.local_addr()?;
@@ -110,11 +118,13 @@ pub(crate) fn build_router(
     miner_telemetry_rx: watch::Receiver<MinerTelemetry>,
     board_registry: Arc<Mutex<BoardRegistry>>,
     scheduler_cmd_tx: mpsc::Sender<SchedulerCommand>,
+    config: Arc<Config>,
 ) -> Router {
     let state = SharedState {
         miner_telemetry_rx,
         board_registry,
         scheduler_cmd_tx,
+        config,
     };
 
     let (router, api) = OpenApiRouter::new()
@@ -143,6 +153,8 @@ mod tests {
     use crate::api::commands::SchedulerCommand;
     use crate::api::registry::BoardRegistration;
     use crate::api_client::types::{BoardTelemetry, SourceTelemetry};
+    use crate::config::{SourceConfig, SourceKind};
+    use crate::stratum_v1::StratumV1PoolConfig;
 
     /// Test fixtures returned by the router builder.
     struct TestFixtures {
@@ -158,6 +170,7 @@ mod tests {
     fn build_test_router(
         miner_state: MinerTelemetry,
         board_states: Vec<BoardTelemetry>,
+        config: Config,
     ) -> TestFixtures {
         let (miner_tx, miner_rx) = watch::channel(miner_state);
         let (cmd_tx, cmd_rx) = mpsc::channel::<SchedulerCommand>(16);
@@ -171,7 +184,12 @@ mod tests {
         }
 
         TestFixtures {
-            router: build_router(miner_rx, Arc::new(Mutex::new(registry)), cmd_tx),
+            router: build_router(
+                miner_rx,
+                Arc::new(Mutex::new(registry)),
+                cmd_tx,
+                Arc::new(config),
+            ),
             _board_senders: board_senders,
             _miner_tx: miner_tx,
             _cmd_rx: cmd_rx,
@@ -191,7 +209,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_returns_ok() {
-        let fixtures = build_test_router(MinerTelemetry::default(), vec![]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], Config::default());
         let (status, body) = get(fixtures.router.clone(), "/api/v0/health").await;
         assert_eq!(status, 200);
         assert_eq!(body, "OK");
@@ -215,7 +233,7 @@ mod tests {
             model: "TestModel".into(),
             ..Default::default()
         };
-        let fixtures = build_test_router(miner_state, vec![board]);
+        let fixtures = build_test_router(miner_state, vec![board], Config::default());
 
         let (status, body) = get(fixtures.router.clone(), "/api/v0/miner").await;
         assert_eq!(status, 200);
@@ -244,7 +262,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let fixtures = build_test_router(MinerTelemetry::default(), boards);
+        let fixtures = build_test_router(MinerTelemetry::default(), boards, Config::default());
 
         let (status, body) = get(fixtures.router.clone(), "/api/v0/boards").await;
         assert_eq!(status, 200);
@@ -263,7 +281,7 @@ mod tests {
             serial: Some("abc123".into()),
             ..Default::default()
         };
-        let fixtures = build_test_router(MinerTelemetry::default(), vec![board]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![board], Config::default());
 
         let (status, body) = get(fixtures.router.clone(), "/api/v0/boards/bitaxe-abc123").await;
         assert_eq!(status, 200);
@@ -275,90 +293,107 @@ mod tests {
 
     #[tokio::test]
     async fn board_by_name_returns_404_when_missing() {
-        let fixtures = build_test_router(MinerTelemetry::default(), vec![]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], Config::default());
         let (status, _body) = get(fixtures.router.clone(), "/api/v0/boards/nonexistent").await;
         assert_eq!(status, 404);
     }
 
     #[tokio::test]
-    async fn sources_returns_list() {
-        let miner_state = MinerTelemetry {
-            sources: vec![
-                SourceTelemetry {
-                    name: "pool-a".into(),
-                    url: Some("stratum+tcp://a:3333".into()),
+    async fn config_returns_configured_sources() {
+        let config = Config {
+            sources: vec![SourceConfig {
+                name: "a".into(),
+                kind: SourceKind::StratumV1(StratumV1PoolConfig {
+                    url: "stratum+tcp://pool.example:3333".into(),
+                    username: "alice.worker1".into(),
+                    password: Some("hunter2".into()),
                     ..Default::default()
-                },
-                SourceTelemetry {
-                    name: "pool-b".into(),
-                    url: None,
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
+                }),
+            }],
         };
-        let fixtures = build_test_router(miner_state, vec![]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], config);
+
+        let (status, body) = get(fixtures.router.clone(), "/api/v0/config").await;
+        assert_eq!(status, 200);
+
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["sources"][0]["name"], "a");
+        assert_eq!(json["sources"][0]["kind"], "stratum_v1");
+        assert_eq!(json["sources"][0]["url"], "stratum+tcp://pool.example:3333");
+        assert_eq!(json["sources"][0]["username"], "alice.worker1");
+        assert_eq!(json["sources"][0]["password"], "hunter2");
+    }
+
+    #[tokio::test]
+    async fn sources_returns_configured_sources() {
+        let config = Config {
+            sources: vec![SourceConfig {
+                name: "a".into(),
+                kind: SourceKind::StratumV1(StratumV1PoolConfig {
+                    url: "stratum+tcp://pool.example:3333".into(),
+                    username: "alice.worker1".into(),
+                    password: None,
+                    ..Default::default()
+                }),
+            }],
+        };
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], config);
 
         let (status, body) = get(fixtures.router.clone(), "/api/v0/sources").await;
         assert_eq!(status, 200);
 
-        let sources: Vec<SourceTelemetry> = serde_json::from_str(&body).unwrap();
-        assert_eq!(sources.len(), 2);
-        assert_eq!(sources[0].name, "pool-a");
-        assert_eq!(sources[0].url.as_deref(), Some("stratum+tcp://a:3333"));
-        assert_eq!(sources[1].name, "pool-b");
-        assert_eq!(sources[1].url, None);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let sources = json.as_array().unwrap();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0]["name"], "a");
+        assert_eq!(sources[0]["kind"], "stratum_v1");
+        assert_eq!(sources[0]["url"], "stratum+tcp://pool.example:3333");
+        assert_eq!(sources[0]["username"], "alice.worker1");
+        assert!(sources[0]["password"].is_null());
+    }
+
+    #[tokio::test]
+    async fn sources_returns_empty_when_no_pools_configured() {
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], Config::default());
+
+        let (status, body) = get(fixtures.router.clone(), "/api/v0/sources").await;
+        assert_eq!(status, 200);
+        assert_eq!(body, "[]");
     }
 
     #[tokio::test]
     async fn source_by_name_returns_match() {
-        let miner_state = MinerTelemetry {
-            sources: vec![SourceTelemetry {
-                name: "my-pool".into(),
-                url: Some("stratum+tcp://pool:3333".into()),
-                ..Default::default()
+        let config = Config {
+            sources: vec![SourceConfig {
+                name: "a".into(),
+                kind: SourceKind::StratumV1(StratumV1PoolConfig {
+                    url: "stratum+tcp://pool.example:3333".into(),
+                    username: "alice.worker1".into(),
+                    password: None,
+                    ..Default::default()
+                }),
             }],
-            ..Default::default()
         };
-        let fixtures = build_test_router(miner_state, vec![]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], config);
 
-        let (status, body) = get(fixtures.router.clone(), "/api/v0/sources/my-pool").await;
+        let (status, body) = get(fixtures.router.clone(), "/api/v0/sources/a").await;
         assert_eq!(status, 200);
 
-        let source: SourceTelemetry = serde_json::from_str(&body).unwrap();
-        assert_eq!(source.name, "my-pool");
-        assert_eq!(source.url.as_deref(), Some("stratum+tcp://pool:3333"));
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["name"], "a");
+        assert_eq!(json["url"], "stratum+tcp://pool.example:3333");
     }
 
     #[tokio::test]
     async fn source_by_name_returns_404_when_missing() {
-        let fixtures = build_test_router(MinerTelemetry::default(), vec![]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], Config::default());
         let (status, _body) = get(fixtures.router.clone(), "/api/v0/sources/nonexistent").await;
         assert_eq!(status, 404);
     }
 
     #[tokio::test]
-    async fn source_difficulty_serializes_as_f64() {
-        let miner_state = MinerTelemetry {
-            sources: vec![SourceTelemetry {
-                name: "pool".into(),
-                difficulty: Some(2048.5),
-                ..Default::default()
-            }],
-            ..Default::default()
-        };
-        let fixtures = build_test_router(miner_state, vec![]);
-
-        let (status, body) = get(fixtures.router.clone(), "/api/v0/sources/pool").await;
-        assert_eq!(status, 200);
-
-        let source: SourceTelemetry = serde_json::from_str(&body).unwrap();
-        assert_eq!(source.difficulty, Some(2048.5));
-    }
-
-    #[tokio::test]
     async fn unknown_route_returns_404() {
-        let fixtures = build_test_router(MinerTelemetry::default(), vec![]);
+        let fixtures = build_test_router(MinerTelemetry::default(), vec![], Config::default());
         let (status, _body) = get(fixtures.router.clone(), "/api/v0/nope").await;
         assert_eq!(status, 404);
     }

--- a/mujina-miner/src/api/v0.rs
+++ b/mujina-miner/src/api/v0.rs
@@ -15,9 +15,8 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 
 use super::commands::SchedulerCommand;
 use super::server::SharedState;
-use crate::api_client::types::{
-    BoardTelemetry, MinerPatchRequest, MinerTelemetry, SourceTelemetry,
-};
+use crate::api_client::types::{BoardTelemetry, MinerPatchRequest, MinerTelemetry};
+use crate::config::{Config, SourceConfig};
 
 /// Build the v0 API routes with OpenAPI metadata.
 pub fn routes() -> OpenApiRouter<SharedState> {
@@ -26,6 +25,7 @@ pub fn routes() -> OpenApiRouter<SharedState> {
         .routes(routes!(get_miner, patch_miner))
         .routes(routes!(get_boards))
         .routes(routes!(get_board))
+        .routes(routes!(get_config))
         .routes(routes!(get_sources))
         .routes(routes!(get_source))
 }
@@ -139,20 +139,33 @@ async fn get_board(
         .ok_or(StatusCode::NOT_FOUND)
 }
 
-/// Return all registered job sources.
+/// Return the full configuration tree.
+#[utoipa::path(
+    get,
+    path = "/config",
+    tag = "config",
+    responses(
+        (status = OK, description = "Current configuration", body = Config),
+    ),
+)]
+async fn get_config(State(state): State<SharedState>) -> Json<Config> {
+    Json((*state.config).clone())
+}
+
+/// Return the configured job sources.
 #[utoipa::path(
     get,
     path = "/sources",
     tag = "sources",
     responses(
-        (status = OK, description = "List of job sources", body = Vec<SourceTelemetry>),
+        (status = OK, description = "List of configured job sources", body = Vec<SourceConfig>),
     ),
 )]
-async fn get_sources(State(state): State<SharedState>) -> Json<Vec<SourceTelemetry>> {
-    Json(state.miner_telemetry_rx.borrow().sources.clone())
+async fn get_sources(State(state): State<SharedState>) -> Json<Vec<SourceConfig>> {
+    Json(state.config.sources.clone())
 }
 
-/// Return a single source by name, or 404 if not found.
+/// Return a single configured job source by name, or 404 if not found.
 #[utoipa::path(
     get,
     path = "/sources/{name}",
@@ -161,17 +174,16 @@ async fn get_sources(State(state): State<SharedState>) -> Json<Vec<SourceTelemet
         ("name" = String, Path, description = "Source name"),
     ),
     responses(
-        (status = OK, description = "Source details", body = SourceTelemetry),
+        (status = OK, description = "Source details", body = SourceConfig),
         (status = NOT_FOUND, description = "Source not found"),
     ),
 )]
 async fn get_source(
     State(state): State<SharedState>,
     Path(name): Path<String>,
-) -> Result<Json<SourceTelemetry>, StatusCode> {
+) -> Result<Json<SourceConfig>, StatusCode> {
     state
-        .miner_telemetry_rx
-        .borrow()
+        .config
         .sources
         .iter()
         .find(|s| s.name == name)

--- a/mujina-miner/src/config.rs
+++ b/mujina-miner/src/config.rs
@@ -7,16 +7,34 @@ use crate::stratum_v1::StratumV1PoolConfig;
 /// Root of the miner's configuration tree.
 #[derive(Debug, Clone, Default)]
 pub struct Config {
-    pub pools: Vec<StratumV1PoolConfig>,
+    pub sources: Vec<SourceKind>,
 }
 
 impl Config {
     /// Read the configuration tree from environment variables.
     pub fn from_env() -> Self {
         Self {
-            pools: stratum_v1_pool_from_env().into_iter().collect(),
+            sources: stratum_v1_pool_from_env()
+                .into_iter()
+                .map(SourceKind::StratumV1)
+                .collect(),
         }
     }
+}
+
+/// What kind of job source this is.
+///
+/// Tagged by `kind` rather than assuming every source is a pool.
+/// "Source" is already the vocabulary the rest of the codebase uses
+/// for this concept (the `job_source` module, `SourceRegistration`,
+/// `SourceEvent`), and it covers more than pool connections: the dummy
+/// source used when none is configured, and, over time, other
+/// protocols (Stratum v2 and whatever comes after). `StratumV1` is the
+/// only variant today; adding a source kind means adding a variant
+/// here, not reshaping this one.
+#[derive(Debug, Clone)]
+pub enum SourceKind {
+    StratumV1(StratumV1PoolConfig),
 }
 
 /// Read Stratum v1 pool configuration from environment variables.
@@ -55,7 +73,7 @@ mod tests {
         unsafe { std::env::remove_var("MUJINA_POOL_URL") };
 
         let config = Config::from_env();
-        assert!(config.pools.is_empty());
+        assert!(config.sources.is_empty());
     }
 
     #[test]
@@ -68,11 +86,12 @@ mod tests {
             std::env::remove_var("MUJINA_POOL_PASS");
         }
 
-        let pools = Config::from_env().pools;
-        assert_eq!(pools.len(), 1);
-        assert_eq!(pools[0].url, "stratum+tcp://pool.example:3333");
-        assert_eq!(pools[0].username, "mujina-testing");
-        assert_eq!(pools[0].password, None);
+        let sources = Config::from_env().sources;
+        assert_eq!(sources.len(), 1);
+        let SourceKind::StratumV1(pool) = &sources[0];
+        assert_eq!(pool.url, "stratum+tcp://pool.example:3333");
+        assert_eq!(pool.username, "mujina-testing");
+        assert_eq!(pool.password, None);
     }
 
     #[test]
@@ -85,9 +104,10 @@ mod tests {
             std::env::set_var("MUJINA_POOL_PASS", "hunter2");
         }
 
-        let pools = Config::from_env().pools;
-        assert_eq!(pools.len(), 1);
-        assert_eq!(pools[0].username, "alice.worker1");
-        assert_eq!(pools[0].password, Some("hunter2".to_string()));
+        let sources = Config::from_env().sources;
+        assert_eq!(sources.len(), 1);
+        let SourceKind::StratumV1(pool) = &sources[0];
+        assert_eq!(pool.username, "alice.worker1");
+        assert_eq!(pool.password, Some("hunter2".to_string()));
     }
 }

--- a/mujina-miner/src/config.rs
+++ b/mujina-miner/src/config.rs
@@ -7,7 +7,7 @@ use crate::stratum_v1::StratumV1PoolConfig;
 /// Root of the miner's configuration tree.
 #[derive(Debug, Clone, Default)]
 pub struct Config {
-    pub sources: Vec<SourceKind>,
+    pub sources: Vec<SourceConfig>,
 }
 
 impl Config {
@@ -16,10 +16,22 @@ impl Config {
         Self {
             sources: stratum_v1_pool_from_env()
                 .into_iter()
-                .map(SourceKind::StratumV1)
+                .enumerate()
+                .map(|(i, pool)| SourceConfig {
+                    name: generated_name(i),
+                    kind: SourceKind::StratumV1(pool),
+                })
                 .collect(),
         }
     }
+}
+
+/// A configured job source.
+#[derive(Debug, Clone)]
+pub struct SourceConfig {
+    /// URL-friendly identifier, unique among sources.
+    pub name: String,
+    pub kind: SourceKind,
 }
 
 /// What kind of job source this is.
@@ -35,6 +47,16 @@ impl Config {
 #[derive(Debug, Clone)]
 pub enum SourceKind {
     StratumV1(StratumV1PoolConfig),
+}
+
+/// Derive a name for a source that has none configured explicitly.
+///
+/// Assigns letters by position (`a`, `b`, `c`, ...). Good enough while
+/// naming can't yet be set explicitly (e.g. per-source in a config file
+/// or env var); once it can, that name should take precedence and this
+/// should only apply to whatever's left unnamed.
+fn generated_name(index: usize) -> String {
+    char::from(b'a' + (index as u8 % 26)).to_string()
 }
 
 /// Read Stratum v1 pool configuration from environment variables.
@@ -88,7 +110,8 @@ mod tests {
 
         let sources = Config::from_env().sources;
         assert_eq!(sources.len(), 1);
-        let SourceKind::StratumV1(pool) = &sources[0];
+        assert_eq!(sources[0].name, "a");
+        let SourceKind::StratumV1(pool) = &sources[0].kind;
         assert_eq!(pool.url, "stratum+tcp://pool.example:3333");
         assert_eq!(pool.username, "mujina-testing");
         assert_eq!(pool.password, None);
@@ -106,7 +129,8 @@ mod tests {
 
         let sources = Config::from_env().sources;
         assert_eq!(sources.len(), 1);
-        let SourceKind::StratumV1(pool) = &sources[0];
+        assert_eq!(sources[0].name, "a");
+        let SourceKind::StratumV1(pool) = &sources[0].kind;
         assert_eq!(pool.username, "alice.worker1");
         assert_eq!(pool.password, Some("hunter2".to_string()));
     }

--- a/mujina-miner/src/config.rs
+++ b/mujina-miner/src/config.rs
@@ -1,101 +1,93 @@
-//! Configuration management for mujina-miner.
+//! Configuration tree for mujina-miner.
 //!
-//! This module handles loading and validating configuration from TOML files,
-//! environment variables, and command-line arguments. It supports hot-reload
-//! via file watching.
+//! Populated from environment variables.
 
-use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use crate::stratum_v1::StratumV1PoolConfig;
 
-/// Main configuration structure for the miner.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// Root of the miner's configuration tree.
+#[derive(Debug, Clone, Default)]
 pub struct Config {
-    /// Daemon configuration
-    pub daemon: DaemonConfig,
-
-    /// Pool configuration
-    pub pools: Vec<PoolConfig>,
-
-    /// Hardware configuration
-    pub hardware: HardwareConfig,
-
-    /// API server configuration
-    pub api: ApiConfig,
-}
-
-/// Daemon process configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct DaemonConfig {
-    /// PID file location
-    pub pid_file: Option<PathBuf>,
-
-    /// Log level
-    pub log_level: String,
-
-    /// Use systemd notification
-    #[serde(default)]
-    pub systemd: bool,
-}
-
-/// Pool connection configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct PoolConfig {
-    /// Pool URL (stratum+tcp://...)
-    pub url: String,
-
-    /// Worker name
-    pub worker: String,
-
-    /// Password (if required)
-    pub password: Option<String>,
-
-    /// Priority (lower is higher priority)
-    #[serde(default)]
-    pub priority: u32,
-}
-
-/// Hardware configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct HardwareConfig {
-    /// Temperature limits
-    pub temp_limit: f32,
-
-    /// Fan control settings
-    pub fan_min_rpm: u32,
-    pub fan_max_rpm: u32,
-
-    /// Power limits
-    pub power_limit: Option<f32>,
-}
-
-/// API server configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ApiConfig {
-    /// Listen address
-    pub listen: String,
-
-    /// Enable TLS
-    #[serde(default)]
-    pub tls: bool,
-
-    /// TLS certificate path
-    pub cert_path: Option<PathBuf>,
-
-    /// TLS key path
-    pub key_path: Option<PathBuf>,
+    pub pools: Vec<StratumV1PoolConfig>,
 }
 
 impl Config {
-    /// Load configuration from the default location.
-    pub fn load() -> anyhow::Result<Self> {
-        // TODO: Implement config loading from /etc/mujina/mujina.toml
-        // and ~/.config/mujina/mujina.toml with proper merging
-        unimplemented!("Config loading not yet implemented")
+    /// Read the configuration tree from environment variables.
+    pub fn from_env() -> Self {
+        Self {
+            pools: stratum_v1_pool_from_env().into_iter().collect(),
+        }
+    }
+}
+
+/// Read Stratum v1 pool configuration from environment variables.
+///
+/// Returns `None` if `MUJINA_POOL_URL` is unset, in which case the
+/// caller should fall back to a dummy job source.
+///
+/// # Environment Variables
+///
+/// - `MUJINA_POOL_URL`: Pool address (e.g. stratum+tcp://host:3333)
+/// - `MUJINA_POOL_USER`: Worker username (default: "mujina-testing")
+/// - `MUJINA_POOL_PASS`: Worker password, if the pool requires one
+fn stratum_v1_pool_from_env() -> Option<StratumV1PoolConfig> {
+    let url = std::env::var("MUJINA_POOL_URL").ok()?;
+    let username =
+        std::env::var("MUJINA_POOL_USER").unwrap_or_else(|_| "mujina-testing".to_string());
+    let password = std::env::var("MUJINA_POOL_PASS").ok();
+
+    Some(StratumV1PoolConfig {
+        url,
+        username,
+        password,
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn from_env_returns_none_when_url_unset() {
+        // SAFETY: Test runs serially, no concurrent env access
+        unsafe { std::env::remove_var("MUJINA_POOL_URL") };
+
+        let config = Config::from_env();
+        assert!(config.pools.is_empty());
     }
 
-    /// Load configuration from a specific file.
-    pub fn load_from(_path: &Path) -> anyhow::Result<Self> {
-        // TODO: Implement TOML parsing
-        unimplemented!("Config loading not yet implemented")
+    #[test]
+    #[serial]
+    fn from_env_defaults_username_and_omits_password_when_unset() {
+        // SAFETY: Test runs serially, no concurrent env access
+        unsafe {
+            std::env::set_var("MUJINA_POOL_URL", "stratum+tcp://pool.example:3333");
+            std::env::remove_var("MUJINA_POOL_USER");
+            std::env::remove_var("MUJINA_POOL_PASS");
+        }
+
+        let pools = Config::from_env().pools;
+        assert_eq!(pools.len(), 1);
+        assert_eq!(pools[0].url, "stratum+tcp://pool.example:3333");
+        assert_eq!(pools[0].username, "mujina-testing");
+        assert_eq!(pools[0].password, None);
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_reads_username_and_password_when_set() {
+        // SAFETY: Test runs serially, no concurrent env access
+        unsafe {
+            std::env::set_var("MUJINA_POOL_URL", "stratum+tcp://pool.example:3333");
+            std::env::set_var("MUJINA_POOL_USER", "alice.worker1");
+            std::env::set_var("MUJINA_POOL_PASS", "hunter2");
+        }
+
+        let pools = Config::from_env().pools;
+        assert_eq!(pools.len(), 1);
+        assert_eq!(pools[0].username, "alice.worker1");
+        assert_eq!(pools[0].password, Some("hunter2".to_string()));
     }
 }

--- a/mujina-miner/src/config.rs
+++ b/mujina-miner/src/config.rs
@@ -2,10 +2,13 @@
 //!
 //! Populated from environment variables.
 
+use serde::Serialize;
+use utoipa::ToSchema;
+
 use crate::stratum_v1::StratumV1PoolConfig;
 
 /// Root of the miner's configuration tree.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
 pub struct Config {
     pub sources: Vec<SourceConfig>,
 }
@@ -27,10 +30,11 @@ impl Config {
 }
 
 /// A configured job source.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SourceConfig {
     /// URL-friendly identifier, unique among sources.
     pub name: String,
+    #[serde(flatten)]
     pub kind: SourceKind,
 }
 
@@ -44,7 +48,8 @@ pub struct SourceConfig {
 /// protocols (Stratum v2 and whatever comes after). `StratumV1` is the
 /// only variant today; adding a source kind means adding a variant
 /// here, not reshaping this one.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SourceKind {
     StratumV1(StratumV1PoolConfig),
 }

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -115,7 +115,7 @@ impl Daemon {
         let pool_config = Config::from_env()
             .sources
             .into_iter()
-            .map(|s| match s {
+            .map(|s| match s.kind {
                 SourceKind::StratumV1(pool) => pool,
             })
             .next();

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -112,11 +112,12 @@ impl Daemon {
         });
 
         // Create job source (Stratum v1 or Dummy)
-        let pool_config = Config::from_env()
+        let config = Config::from_env();
+        let pool_config = config
             .sources
-            .into_iter()
-            .map(|s| match s.kind {
-                SourceKind::StratumV1(pool) => pool,
+            .iter()
+            .map(|s| match &s.kind {
+                SourceKind::StratumV1(pool) => pool.clone(),
             })
             .next();
         let (source_event_tx, source_event_rx) = mpsc::channel::<SourceEvent>(100);
@@ -256,13 +257,14 @@ impl Daemon {
                     Ok(addr) => format!("{addr}:{API_PORT}"),
                     Err(_) => format!("127.0.0.1:{API_PORT}"),
                 };
-                let config = ApiConfig { bind_addr };
+                let api_config = ApiConfig { bind_addr };
                 if let Err(e) = api::serve(
-                    config,
+                    api_config,
                     shutdown,
                     miner_telemetry_rx,
                     board_reg_rx,
                     scheduler_cmd_tx,
+                    config,
                 )
                 .await
                 {

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -14,6 +14,7 @@ use crate::tracing::prelude::*;
 use crate::{
     api::{self, ApiConfig, commands::SchedulerCommand},
     backplane::Backplane,
+    config::Config,
     cpu_miner::CpuMinerConfig,
     job_source::{
         SourceCommand, SourceEvent,
@@ -22,7 +23,7 @@ use crate::{
         stratum_v1::StratumV1Source,
     },
     scheduler::{self, SourceRegistration, ThreadRegistration},
-    stratum_v1::{StratumV1PoolConfig, TcpConnector},
+    stratum_v1::TcpConnector,
     transport::{CpuDeviceInfo, TransportEvent, UsbTransport, cpu as cpu_transport},
 };
 
@@ -111,25 +112,13 @@ impl Daemon {
         });
 
         // Create job source (Stratum v1 or Dummy)
-        // Controlled by environment variables:
-        // - MUJINA_POOL_URL: Pool address (e.g., stratum+tcp://localhost:3333)
-        // - MUJINA_POOL_USER: Worker username (optional, defaults to "mujina-testing")
-        // - MUJINA_POOL_PASS: Worker password (optional, defaults to "x")
+        let pool_config = Config::from_env().pools.into_iter().next();
         let (source_event_tx, source_event_rx) = mpsc::channel::<SourceEvent>(100);
         let (source_cmd_tx, source_cmd_rx) = mpsc::channel(10);
 
-        if let Ok(pool_url) = env::var("MUJINA_POOL_URL") {
+        if let Some(stratum_config) = pool_config {
             // Use Stratum v1 source
-            let pool_user =
-                env::var("MUJINA_POOL_USER").unwrap_or_else(|_| "mujina-testing".to_string());
-            let pool_pass = env::var("MUJINA_POOL_PASS").ok();
-
-            let stratum_config = StratumV1PoolConfig {
-                url: pool_url.clone(),
-                username: pool_user,
-                password: pool_pass,
-                user_agent: "mujina-miner/0.1.0-alpha".to_string(),
-            };
+            let pool_url = stratum_config.url.clone();
 
             // Optionally wrap with ForcedRateSource for testing
             if let Some(forced_rate_config) = ForcedRateConfig::from_env() {

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -14,7 +14,7 @@ use crate::tracing::prelude::*;
 use crate::{
     api::{self, ApiConfig, commands::SchedulerCommand},
     backplane::Backplane,
-    config::Config,
+    config::{Config, SourceKind},
     cpu_miner::CpuMinerConfig,
     job_source::{
         SourceCommand, SourceEvent,
@@ -112,7 +112,13 @@ impl Daemon {
         });
 
         // Create job source (Stratum v1 or Dummy)
-        let pool_config = Config::from_env().pools.into_iter().next();
+        let pool_config = Config::from_env()
+            .sources
+            .into_iter()
+            .map(|s| match s {
+                SourceKind::StratumV1(pool) => pool,
+            })
+            .next();
         let (source_event_tx, source_event_rx) = mpsc::channel::<SourceEvent>(100);
         let (source_cmd_tx, source_cmd_rx) = mpsc::channel(10);
 

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -22,7 +22,7 @@ use crate::{
         stratum_v1::StratumV1Source,
     },
     scheduler::{self, SourceRegistration, ThreadRegistration},
-    stratum_v1::{PoolConfig as StratumPoolConfig, TcpConnector},
+    stratum_v1::{StratumV1PoolConfig, TcpConnector},
     transport::{CpuDeviceInfo, TransportEvent, UsbTransport, cpu as cpu_transport},
 };
 
@@ -124,7 +124,7 @@ impl Daemon {
                 env::var("MUJINA_POOL_USER").unwrap_or_else(|_| "mujina-testing".to_string());
             let pool_pass = env::var("MUJINA_POOL_PASS").unwrap_or_else(|_| "x".to_string());
 
-            let stratum_config = StratumPoolConfig {
+            let stratum_config = StratumV1PoolConfig {
                 url: pool_url.clone(),
                 username: pool_user,
                 password: pool_pass,

--- a/mujina-miner/src/daemon.rs
+++ b/mujina-miner/src/daemon.rs
@@ -122,7 +122,7 @@ impl Daemon {
             // Use Stratum v1 source
             let pool_user =
                 env::var("MUJINA_POOL_USER").unwrap_or_else(|_| "mujina-testing".to_string());
-            let pool_pass = env::var("MUJINA_POOL_PASS").unwrap_or_else(|_| "x".to_string());
+            let pool_pass = env::var("MUJINA_POOL_PASS").ok();
 
             let stratum_config = StratumV1PoolConfig {
                 url: pool_url.clone(),

--- a/mujina-miner/src/job_source/stratum_v1.rs
+++ b/mujina-miner/src/job_source/stratum_v1.rs
@@ -15,7 +15,7 @@ use tokio::time::{self, Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::stratum_v1::{
-    ClientCommand, ClientEvent, Connector, JobNotification, PoolConfig, StratumV1Client,
+    ClientCommand, ClientEvent, Connector, JobNotification, StratumV1Client, StratumV1PoolConfig,
 };
 use crate::tracing::prelude::*;
 use crate::types::{Difficulty, HashRate, ShareRate};
@@ -121,7 +121,7 @@ enum ConnectOutcome {
 /// messages to JobTemplates and outgoing Share submissions to Stratum format.
 pub struct StratumV1Source {
     /// Pool configuration
-    config: PoolConfig,
+    config: StratumV1PoolConfig,
 
     /// Where to send events to scheduler
     event_tx: mpsc::Sender<SourceEvent>,
@@ -170,7 +170,7 @@ struct ProtocolState {
 impl StratumV1Source {
     /// Create a new Stratum v1 source.
     pub fn new(
-        config: PoolConfig,
+        config: StratumV1PoolConfig,
         command_rx: mpsc::Receiver<SourceCommand>,
         event_tx: mpsc::Sender<SourceEvent>,
         shutdown: CancellationToken,
@@ -758,7 +758,7 @@ mod tests {
         let (_command_tx, command_rx) = mpsc::channel(10);
         let shutdown = CancellationToken::new();
 
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             username: "testworker".to_string(),
             password: "x".to_string(),
@@ -1186,7 +1186,7 @@ mod tests {
         let (event_tx, _event_rx) = mpsc::channel(10);
         let (_command_tx, command_rx) = mpsc::channel(10);
         let shutdown = CancellationToken::new();
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             ..Default::default()
         };
@@ -1245,7 +1245,7 @@ mod tests {
     fn throttle_test_source() -> StratumV1Source {
         let (event_tx, _event_rx) = mpsc::channel(10);
         let (_command_tx, command_rx) = mpsc::channel(10);
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             ..Default::default()
         };
@@ -1356,7 +1356,7 @@ mod tests {
         let (event_tx, _event_rx) = mpsc::channel(10);
         let (_command_tx, command_rx) = mpsc::channel(10);
         let shutdown = CancellationToken::new();
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             ..Default::default()
         };
@@ -1389,7 +1389,7 @@ mod tests {
         let (event_tx, _event_rx) = mpsc::channel(10);
         let (_command_tx, command_rx) = mpsc::channel(10);
         let shutdown = CancellationToken::new();
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             ..Default::default()
         };
@@ -1424,7 +1424,7 @@ mod tests {
         let (event_tx, _event_rx) = mpsc::channel(10);
         let (_command_tx, command_rx) = mpsc::channel(10);
         let shutdown = CancellationToken::new();
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             ..Default::default()
         };
@@ -1587,7 +1587,7 @@ mod tests {
         let shutdown = CancellationToken::new();
         let (mock_tx, mock_rx) = mpsc::channel(10);
 
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             username: "testworker".to_string(),
             password: "x".to_string(),

--- a/mujina-miner/src/job_source/stratum_v1.rs
+++ b/mujina-miner/src/job_source/stratum_v1.rs
@@ -761,7 +761,7 @@ mod tests {
         let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             username: "testworker".to_string(),
-            password: "x".to_string(),
+            password: Some("x".to_string()),
             user_agent: "test".to_string(),
             ..Default::default()
         };
@@ -1590,7 +1590,7 @@ mod tests {
         let config = StratumV1PoolConfig {
             url: "stratum+tcp://test:3333".to_string(),
             username: "testworker".to_string(),
-            password: "x".to_string(),
+            password: Some("x".to_string()),
             user_agent: "test".to_string(),
             ..Default::default()
         };

--- a/mujina-miner/src/stratum_v1/client.rs
+++ b/mujina-miner/src/stratum_v1/client.rs
@@ -5,6 +5,9 @@
 
 use std::time::Duration;
 
+use serde::Serialize;
+use utoipa::ToSchema;
+
 use super::connection::{Connection, Transport};
 use super::error::{StratumError, StratumResult};
 use super::messages::{ClientCommand, ClientEvent, JsonRpcMessage, SubmitParams};
@@ -15,8 +18,10 @@ use tokio_util::sync::CancellationToken;
 /// Pool connection configuration.
 ///
 /// `Debug` is hand-implemented to redact the password, since `Debug`
-/// output can end up in trace logs.
-#[derive(Clone)]
+/// output can end up in trace logs. `Serialize` is derived and does
+/// include it: the config API is how an operator inspects their own
+/// pool configuration.
+#[derive(Clone, Serialize, ToSchema)]
 pub struct StratumV1PoolConfig {
     /// Pool URL (stratum+tcp://host:port or host:port)
     pub url: String,

--- a/mujina-miner/src/stratum_v1/client.rs
+++ b/mujina-miner/src/stratum_v1/client.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 /// Pool connection configuration.
 #[derive(Debug, Clone)]
-pub struct PoolConfig {
+pub struct StratumV1PoolConfig {
     /// Pool URL (stratum+tcp://host:port or host:port)
     pub url: String,
 
@@ -28,7 +28,7 @@ pub struct PoolConfig {
     pub user_agent: String,
 }
 
-impl Default for PoolConfig {
+impl Default for StratumV1PoolConfig {
     fn default() -> Self {
         Self {
             url: String::new(),
@@ -49,7 +49,7 @@ impl Default for PoolConfig {
 /// we process notifications inline while waiting for responses.
 pub struct StratumV1Client {
     /// Pool configuration
-    config: PoolConfig,
+    config: StratumV1PoolConfig,
 
     /// Where to send events
     event_tx: mpsc::Sender<ClientEvent>,
@@ -91,7 +91,7 @@ struct ProtocolState {
 impl StratumV1Client {
     /// Create a new Stratum v1 client.
     pub fn new(
-        config: PoolConfig,
+        config: StratumV1PoolConfig,
         event_tx: mpsc::Sender<ClientEvent>,
         shutdown: CancellationToken,
     ) -> Self {
@@ -108,7 +108,7 @@ impl StratumV1Client {
 
     /// Create a new Stratum v1 client with command channel.
     pub fn with_commands(
-        config: PoolConfig,
+        config: StratumV1PoolConfig,
         event_tx: mpsc::Sender<ClientEvent>,
         command_rx: mpsc::Receiver<ClientCommand>,
         shutdown: CancellationToken,
@@ -943,7 +943,7 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::channel(100);
         let shutdown = CancellationToken::new();
 
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: format!("stratum+tcp://{}", pool_url),
             username: username.to_string(),
             password: "x".to_string(),
@@ -1105,7 +1105,7 @@ mod tests {
         let (event_tx, event_rx) = mpsc::channel(10);
         let shutdown = CancellationToken::new();
 
-        let config = PoolConfig {
+        let config = StratumV1PoolConfig {
             url: "test:3333".to_string(),
             username: "test".to_string(),
             password: "x".to_string(),

--- a/mujina-miner/src/stratum_v1/client.rs
+++ b/mujina-miner/src/stratum_v1/client.rs
@@ -13,7 +13,10 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 /// Pool connection configuration.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is hand-implemented to redact the password, since `Debug`
+/// output can end up in trace logs.
+#[derive(Clone)]
 pub struct StratumV1PoolConfig {
     /// Pool URL (stratum+tcp://host:port or host:port)
     pub url: String,
@@ -21,8 +24,10 @@ pub struct StratumV1PoolConfig {
     /// Worker username
     pub username: String,
 
-    /// Worker password
-    pub password: String,
+    /// Worker password, if the pool requires one. `None` means no
+    /// password was configured, distinct from an explicitly empty one;
+    /// callers that need a wire value default to "x" at send time.
+    pub password: Option<String>,
 
     /// User agent string
     pub user_agent: String,
@@ -33,9 +38,20 @@ impl Default for StratumV1PoolConfig {
         Self {
             url: String::new(),
             username: String::new(),
-            password: String::new(),
+            password: None,
             user_agent: "mujina-miner/0.1.0-alpha".to_string(),
         }
+    }
+}
+
+impl std::fmt::Debug for StratumV1PoolConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StratumV1PoolConfig")
+            .field("url", &self.url)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "[redacted]"))
+            .field("user_agent", &self.user_agent)
+            .finish()
     }
 }
 
@@ -364,7 +380,10 @@ impl StratumV1Client {
             .send_request(
                 conn,
                 "mining.authorize",
-                json!([&self.config.username, &self.config.password]),
+                json!([
+                    &self.config.username,
+                    self.config.password.as_deref().unwrap_or("x")
+                ]),
                 Duration::from_secs(30),
             )
             .await?;
@@ -946,7 +965,7 @@ mod tests {
         let config = StratumV1PoolConfig {
             url: format!("stratum+tcp://{}", pool_url),
             username: username.to_string(),
-            password: "x".to_string(),
+            password: Some("x".to_string()),
             user_agent: "mujina-miner/0.1.0-test".to_string(),
         };
 
@@ -1108,7 +1127,7 @@ mod tests {
         let config = StratumV1PoolConfig {
             url: "test:3333".to_string(),
             username: "test".to_string(),
-            password: "x".to_string(),
+            password: Some("x".to_string()),
             user_agent: "test".to_string(),
         };
 

--- a/mujina-miner/src/stratum_v1/mod.rs
+++ b/mujina-miner/src/stratum_v1/mod.rs
@@ -21,10 +21,10 @@
 //! # Usage
 //!
 //! ```rust,ignore
-//! use stratum_v1::{StratumV1Client, ClientEvent, PoolConfig};
+//! use stratum_v1::{StratumV1Client, ClientEvent, StratumV1PoolConfig};
 //!
 //! let (event_tx, mut event_rx) = mpsc::channel(100);
-//! let config = PoolConfig {
+//! let config = StratumV1PoolConfig {
 //!     url: "stratum+tcp://pool.example.com:3333".to_string(),
 //!     username: "worker".to_string(),
 //!     password: "x".to_string(),
@@ -47,7 +47,7 @@ mod connection;
 mod error;
 mod messages;
 
-pub use client::{PoolConfig, StratumV1Client};
+pub use client::{StratumV1Client, StratumV1PoolConfig};
 pub use connection::{Connector, TcpConnector, Transport};
 #[cfg(test)]
 pub(crate) use connection::{MockConnector, MockTransport, MockTransportHandle};


### PR DESCRIPTION
## Summary

Implements the first two phases of the incremental plan agreed on in [mujina-mips#1](https://github.com/256foundation/mujina-mips/pull/1) for [MIP-0001](https://github.com/256foundation/mujina-mips/blob/mip-configuration-and-api/mip-0001-configuration-and-api.md) (configuration & API), using pool configuration as the pilot feature per Ryan's suggestion on [#83](https://github.com/256foundation/mujina/issues/83):

1. Replace the unimplemented `Config` stub with a real tree, populated from env vars.
2. Serve that tree read-only over the existing `/api/v0` HTTP API.

Closes #83.

## Scope

Read-only, in-memory, no persistence, no write path for now.

[MIP-0001 DR-1:](https://github.com/rkuester/mujina-mips/blob/mip-configuration-and-api/mip-0001-configuration-and-api.md#dr1-the-configuration-tree-is-one-object)
> There is no separate "API shape" and "internal shape" of configuration that the daemon has to keep in sync, and no conversion code between them.

Structs serialize directly and do include the plaintext pool password. The trust model remains the same, as the API has no authentication or authorization yet.

## What changed

- `Config` is now populated by `Config::from_env()`, and `daemon.rs` builds its job source directly from the tree instead of reading `MUJINA_POOL_*` env vars itself.
- The config tree reuses `stratum_v1::StratumV1PoolConfig` (renamed from `PoolConfig`) rather than defining a second, near-identical type for the API. That's the DR-1 point above applied literally: `daemon.rs` no longer hand-converts one pool-config shape into another before constructing a `StratumV1Source` — the value extracted from the tree already is the type the wire client needs.
- `StratumV1PoolConfig.password` is now `Option<String>`, so an unset password stays distinguishable from an explicitly empty one; the wire-level `"x"` default moved from the daemon into `StratumV1Client::authorize()`, the one place it's actually needed.
- `GET /api/v0/config` returns the full configuration tree; `GET /api/v0/sources` and `GET /api/v0/sources/{name}` return the configured job sources, replacing the old telemetry-backed `/sources`.
- Sources are typed as a `kind`-tagged enum (`SourceKind`) rather than assuming every source is a pool. `"stratum_v1"` is the only kind today; the tag lets a future consumer respond additively as new kinds are added — the dummy source used when none is configured, and, over time, other protocols — instead of needing a breaking shape change later. "Source" is also the vocabulary the rest of the codebase already uses for this concept (the `job_source` module, `SourceRegistration`, `SourceEvent`), so the config tree's naming now matches it.

## Comments

- The spec mentions `256fdn` as a possible name for a source, but since we don't have an env var to name a source, nor a more advanced config file system yet, we only assign an incrementing character like a, b, c, and so on. We could introduce a name property with its own env var, or simply skip it for now and wait for config files to land.