### PR TITLE
fix(stratum_v1): bound pool reads by length and idle time

### DIFF
--- a/mujina-miner/src/job_source/stratum_v1.rs
+++ b/mujina-miner/src/job_source/stratum_v1.rs
@@ -53,6 +53,25 @@ const SUGGEST_MIN_INTERVAL: Duration = Duration::from_secs(5);
 /// flapping pool that accepts and immediately drops.
 const STABLE_CONNECTION_THRESHOLD: Duration = Duration::from_secs(60);
 
+/// Initial delay before reconnecting after a dropped connection.
+/// Doubles on each failed attempt, jittered to [0.5, 1.0] of nominal.
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+
+/// Ceiling for the exponential reconnect backoff.
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(60);
+
+/// Maximum tolerated gap between jobs before the source recycles the
+/// connection.
+///
+/// Stratum defines no liveness; the job source judges pool health by
+/// the arrival of fresh work. A healthy pool sends fresh work every
+/// half minute or faster. A public-pool capture shows 6--36 s gaps
+/// between jobs, HydraPool notifies on every tick of its 10 s
+/// template poll, and cgminer has treated 90 seconds of silence as a
+/// dead pool for over a decade. Two minutes spans several refresh
+/// intervals.
+const MAX_JOB_GAP: Duration = Duration::from_secs(2 * 60);
+
 /// Exponential backoff for reconnection timing.
 ///
 /// Starts at `initial` and doubles after each call to `next_delay()`,
@@ -518,7 +537,7 @@ impl StratumV1Source {
         }
 
         // Phase 2: connect with automatic reconnection.
-        let mut backoff = ExponentialBackoff::new(Duration::from_secs(1), Duration::from_secs(60));
+        let mut backoff = ExponentialBackoff::new(INITIAL_RECONNECT_DELAY, MAX_RECONNECT_DELAY);
 
         loop {
             // Reset per-connection state so a fresh handshake starts clean.
@@ -599,6 +618,9 @@ impl StratumV1Source {
         let client_handle = tokio::spawn(async move { client.run_with_transport(transport).await });
 
         // Main event loop
+
+        let mut gap_start = Instant::now();
+
         loop {
             // Copied out so the cooldown branch captures the value, not `self`.
             let cooldown_until = self.cooldown_until;
@@ -606,6 +628,9 @@ impl StratumV1Source {
                 event_opt = client_event_rx.recv() => {
                     match event_opt {
                         Some(event) => {
+                            if matches!(event, ClientEvent::NewJob(_)) {
+                                gap_start = Instant::now();
+                            }
                             if let Err(e) = self.handle_client_event(event).await {
                                 warn!(error = %e, "Error handling client event");
                             }
@@ -658,6 +683,15 @@ impl StratumV1Source {
                     self.flush_suggest(&client_command_tx).await;
                 }
 
+                _ = time::sleep_until(gap_start + MAX_JOB_GAP) => {
+                    warn!(
+                        gap_secs = MAX_JOB_GAP.as_secs(),
+                        "No job from pool within the gap limit; recycling the connection"
+                    );
+                    client_handle.abort();
+                    break;
+                }
+
                 _ = self.shutdown.cancelled() => {
                     return ConnectOutcome::Shutdown;
                 }
@@ -674,6 +708,11 @@ impl StratumV1Source {
                     warn!(error = %e, "Disconnected from pool");
                     ConnectOutcome::Disconnected
                 }
+            }
+            Err(join_err) if join_err.is_cancelled() => {
+                // The source killed the client; so it was an
+                // intentional disconnect, not a crash.
+                ConnectOutcome::Disconnected
             }
             Err(join_err) => {
                 ConnectOutcome::Fatal(anyhow::anyhow!("Client task panicked: {}", join_err))
@@ -1655,6 +1694,99 @@ mod tests {
         assert!(
             matches!(event, SourceEvent::ReplaceJob(ref t) if t.id == "job-2"),
             "expected ReplaceJob(job-2), got {event:?}",
+        );
+
+        shutdown.cancel();
+        source_handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recycles_connection_after_job_silence() {
+        let (source, mut event_rx, command_tx, mock_tx, shutdown) = source_with_mock_transports();
+
+        let (transport1, mut handle1) = MockTransport::pair();
+        let (transport2, mut handle2) = MockTransport::pair();
+        mock_tx.send(transport1).await.unwrap();
+        mock_tx.send(transport2).await.unwrap();
+
+        let source_handle = tokio::spawn(source.run());
+
+        command_tx
+            .send(SourceCommand::UpdateHashRate(HashRate::from_gigahashes(
+                500.0,
+            )))
+            .await
+            .unwrap();
+
+        // First connection: handshake completes, then the pool sends
+        // difficulty updates but never a job.
+        do_handshake(&mut handle1).await;
+        handle1.send(JsonRpcMessage::notification(
+            "mining.set_difficulty",
+            json!([1024]),
+        ));
+
+        // Once MAX_JOB_GAP passes, the source kills the connection and
+        // clears jobs.
+        let event = event_rx.recv().await.unwrap();
+        assert!(
+            matches!(event, SourceEvent::ClearJobs),
+            "expected ClearJobs after job silence, got {event:?}",
+        );
+
+        // Advance past the first backoff; jitter caps it at
+        // INITIAL_RECONNECT_DELAY.
+        time::advance(INITIAL_RECONNECT_DELAY * 2).await;
+
+        // Second connection: handshake, receive a job.
+        do_handshake(&mut handle2).await;
+        handle2.send(job_notification("job-2"));
+
+        let event = event_rx.recv().await.unwrap();
+        assert!(
+            matches!(event, SourceEvent::ReplaceJob(ref t) if t.id == "job-2"),
+            "expected ReplaceJob(job-2) on the new connection, got {event:?}",
+        );
+
+        shutdown.cancel();
+        source_handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fresh_job_defers_recycling() {
+        let (source, mut event_rx, command_tx, mock_tx, shutdown) = source_with_mock_transports();
+
+        let (transport1, mut handle1) = MockTransport::pair();
+        mock_tx.send(transport1).await.unwrap();
+
+        let source_handle = tokio::spawn(source.run());
+
+        command_tx
+            .send(SourceCommand::UpdateHashRate(HashRate::from_gigahashes(
+                500.0,
+            )))
+            .await
+            .unwrap();
+
+        do_handshake(&mut handle1).await;
+
+        // A job three quarters of the way to the deadline restarts
+        // the gap clock.
+        time::advance(MAX_JOB_GAP * 3 / 4).await;
+        handle1.send(job_notification("job-1"));
+        let event = event_rx.recv().await.unwrap();
+        assert!(
+            matches!(event, SourceEvent::ReplaceJob(ref t) if t.id == "job-1"),
+            "expected ReplaceJob(job-1), got {event:?}",
+        );
+
+        // Half a gap later the original deadline has passed, but the
+        // gap runs from the job, so the connection survives.
+        time::advance(MAX_JOB_GAP / 2).await;
+        tokio::task::yield_now().await;
+        assert!(
+            event_rx.try_recv().is_err(),
+            "connection recycled despite a fresh job",
         );
 
         shutdown.cancel();

--- a/mujina-miner/src/stratum_v1/client.rs
+++ b/mujina-miner/src/stratum_v1/client.rs
@@ -770,7 +770,8 @@ impl StratumV1Client {
                         ClientCommand::SubmitShare(params) => {
                             debug!(pool = %self.config.url, job_id = %params.job_id, "Submitting share");
                             if let Err(e) = self.submit(&mut conn, params).await {
-                                warn!(pool = %self.config.url, error = %e, "Failed to submit share");
+                                warn!(pool = %self.config.url, error = %e, "Share submission failed; disconnecting");
+                                return Err(e);
                             }
                             // Acceptance/rejection emitted via ShareAccepted/ShareRejected events
                         }
@@ -799,6 +800,8 @@ mod tests {
     use crate::job_source::Extranonce2;
     use bitcoin::hashes::Hash;
     use tokio::time::{Duration, timeout};
+
+    use super::super::connection::{MockTransport, MockTransportHandle};
 
     /// Integration test: Connect to public-pool.io and validate protocol.
     ///
@@ -1385,5 +1388,72 @@ mod tests {
             }
             _ => panic!("Expected ShareRejected, got {:?}", event),
         }
+    }
+
+    /// Completes the handshake by answering the client's configure,
+    /// subscribe, and authorize requests over the mock transport.
+    async fn answer_handshake(handle: &mut MockTransportHandle) {
+        use serde_json::json;
+
+        for result in [
+            json!({"version-rolling": false}),
+            json!([[], "aabbccdd", 4]),
+            json!(true),
+        ] {
+            let msg = handle.recv().await;
+            handle.send(JsonRpcMessage::Response {
+                id: msg.id().unwrap(),
+                result: Some(result),
+                error: None,
+            });
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_unanswered_submit_disconnects() {
+        // A share submission the pool never answers must end the
+        // connection so the source can reconnect.
+        let (event_tx, _event_rx) = mpsc::channel(10);
+        let (command_tx, command_rx) = mpsc::channel(10);
+        let config = PoolConfig {
+            url: "test:3333".to_string(),
+            username: "test".to_string(),
+            password: "x".to_string(),
+            user_agent: "test".to_string(),
+        };
+        let client = StratumV1Client::with_commands(
+            config,
+            event_tx,
+            command_rx,
+            CancellationToken::new(),
+            None,
+        );
+
+        let (transport, mut handle) = MockTransport::pair();
+        let client_task = tokio::spawn(async move { client.run_with_transport(transport).await });
+        answer_handshake(&mut handle).await;
+
+        // The pool stays silent after this submission.
+        command_tx
+            .send(ClientCommand::SubmitShare(SubmitParams {
+                username: "test".to_string(),
+                job_id: "1".to_string(),
+                extranonce2: vec![0, 0, 0, 0],
+                ntime: 0,
+                nonce: 0,
+                version_bits: None,
+            }))
+            .await
+            .unwrap();
+
+        // The client disconnects by exiting with an error and dropping
+        // the transport; the error is non-fatal so the source knows to
+        // reconnect.
+        let err = timeout(Duration::from_secs(60), client_task)
+            .await
+            .expect("client did not disconnect within the guard timeout")
+            .unwrap()
+            .expect_err("client should disconnect");
+        assert!(!err.is_fatal(), "disconnect must be retryable: {:?}", err);
     }
 }

--- a/mujina-miner/src/stratum_v1/connection.rs
+++ b/mujina-miner/src/stratum_v1/connection.rs
@@ -10,9 +10,25 @@ use async_trait::async_trait;
 use super::error::{StratumError, StratumResult};
 use super::messages::JsonRpcMessage;
 use crate::tracing::prelude::*;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+
+/// Maximum accepted length of a single Stratum message, in bytes.
+///
+/// A `mining.notify` is the largest legitimate message, and its size
+/// is dominated by the hex-encoded coinbase transaction, so this cap
+/// also bounds the coinbase a pool can deliver, about 31 KB
+/// serialized after the notify's fixed fields. A P2WPKH payout
+/// output serializes to 31 bytes and a P2TR output to 43, so that is
+/// room for 750--1000 payouts to miner addresses. Pools that pay
+/// miners in the coinbase send the largest coinbases observed;
+/// recent coinbases from the Ocean pool measure a few dozen outputs,
+/// about 2 KB (mempool.space, Aug 2026). The cap matters because
+/// the transport is plaintext and the peer untrusted. Without it, a
+/// peer that never terminates a line grows the read buffer until
+/// the daemon runs out of memory.
+const MAX_MESSAGE_LEN: usize = 64 * 1024;
 
 /// Message-level I/O for Stratum protocol.
 ///
@@ -88,15 +104,23 @@ impl Transport for Connection {
         loop {
             self.line_buf.clear();
 
-            let n = self
-                .reader
-                .read_line(&mut self.line_buf)
-                .await
-                .map_err(StratumError::Io)?;
+            // Bound the read so an unterminated line cannot grow the
+            // buffer without limit.
+            let n = {
+                let mut limited = (&mut self.reader).take(MAX_MESSAGE_LEN as u64 + 1);
+                limited
+                    .read_line(&mut self.line_buf)
+                    .await
+                    .map_err(StratumError::Io)?
+            };
 
             if n == 0 {
                 // EOF - connection closed
                 return Ok(None);
+            }
+
+            if self.line_buf.len() > MAX_MESSAGE_LEN {
+                return Err(StratumError::MessageTooLarge(MAX_MESSAGE_LEN));
             }
 
             let line = self.line_buf.trim();
@@ -307,5 +331,55 @@ mod tests {
         let response = conn.read_message().await.unwrap().unwrap();
         assert_eq!(response.id(), Some(1));
         assert_eq!(response.method(), Some("test.method"));
+    }
+
+    #[tokio::test]
+    async fn test_oversized_message_rejected() {
+        // A peer that sends an unterminated over-limit line must not be
+        // able to grow the read buffer without bound.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            // One byte past the limit, no newline anywhere.
+            socket
+                .write_all(&vec![b'a'; MAX_MESSAGE_LEN + 1])
+                .await
+                .unwrap();
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let mut conn = Connection::new(stream);
+
+        let result = conn.read_message().await;
+        assert!(
+            matches!(result, Err(StratumError::MessageTooLarge(..))),
+            "expected MessageTooLarge, got {:?}",
+            result,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_length_message_accepted() {
+        // A well-formed message of exactly the maximum length parses.
+        // Pad the method string so the line fills the cap exactly.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let template =
+                |method: &str| format!("{{\"id\":null,\"method\":\"{method}\",\"params\":[]}}\n");
+            let line = template(&"x".repeat(MAX_MESSAGE_LEN - template("").len()));
+            assert_eq!(line.len(), MAX_MESSAGE_LEN);
+            socket.write_all(line.as_bytes()).await.unwrap();
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let mut conn = Connection::new(stream);
+
+        let msg = conn.read_message().await.unwrap().unwrap();
+        assert!(msg.is_notification());
     }
 }

--- a/mujina-miner/src/stratum_v1/error.rs
+++ b/mujina-miner/src/stratum_v1/error.rs
@@ -17,6 +17,13 @@ pub enum StratumError {
     #[error("Invalid message format: {0}")]
     InvalidMessage(String),
 
+    /// Message from pool exceeded the maximum accepted length
+    ///
+    /// Always terminates the connection; the caller reconnects with
+    /// backoff.
+    #[error("Message exceeds {0}-byte limit")]
+    MessageTooLarge(usize),
+
     /// Pool returned an error response
     #[error("Pool error: {0}")]
     PoolError(String),


### PR DESCRIPTION
## Problem

Two related robustness gaps in the stratum client, both reachable by a malicious pool or a MITM (the transport is plaintext):

1. **Unbounded read buffer** — `Connection::read_message` loops `BufReader::read_line` into a growable `String` with no length cap. A peer that never sends `\n` grows the daemon's memory until the OOM killer ends it (≈1 GB per 25 s at 100 Mbps, or arbitrarily slowly via a drip).
2. **No idle timeout** — the main event loop awaits pool messages with no timeout. A dead or deliberately silent connection leaves the miner neither working nor reconnecting; TCP keepalive takes hours to notice.

Found during a source review of the pool-facing input handling.

## Fix

- **Cap messages at 64 KiB** (`MAX_MESSAGE_LEN`): the read goes through a length-limited adapter, and a line that fills the cap without a terminating newline is rejected with a new `StratumError::MessageTooLarge`. 64 KiB is ~10× the largest legitimate message (`mining.notify` with a big coinbase and many merkle branches). The error terminates the connection; the source reconnects with the usual jittered backoff.
- **20-minute idle timeout** (`POOL_IDLE_TIMEOUT`) around pool reads in the client main loop. Pools send `mining.notify` at least as often as new blocks arrive (10 min average), so 20 minutes of silence means the connection is dead; a timeout errors the connection and triggers the normal reconnect path.

Neither change affects the handshake/submit paths, which already have 30 s request timeouts.

## Tests

- `test_oversized_message_rejected`: an unterminated 64 KiB+1 line is rejected with `MessageTooLarge`.
- `test_max_length_message_accepted`: a well-formed message just under the cap still parses.
- `test_silent_pool_recycles_connection`: paused-time test; after a mock handshake the pool says nothing and the client exits with `Timeout`, i.e. the caller reconnects.

`cargo fmt`, `cargo clippy` (no new warnings), and `cargo test` (355 passed) are green; each commit passes on its own.