### PR TITLE
fix: validate pool-controlled extranonce2_size and bound its consumers

### DIFF
--- a/mujina-miner/src/cpu_miner/config.rs
+++ b/mujina-miner/src/cpu_miner/config.rs
@@ -2,6 +2,15 @@
 //!
 //! Parses environment variables to configure the CPU mining backend.
 
+use crate::tracing::prelude::*;
+
+/// Upper bound on CPU mining threads.
+///
+/// The CPU backend exists for development and testing, so this is far
+/// above any real core count; the bound keeps a typo in
+/// `MUJINA_CPUMINER_THREADS` from spawning an absurd number of threads.
+const MAX_THREAD_COUNT: usize = 4096;
+
 /// CPU miner configuration parsed from environment variables.
 #[derive(Debug, Clone)]
 pub struct CpuMinerConfig {
@@ -27,9 +36,18 @@ impl CpuMinerConfig {
     /// - `MUJINA_CPUMINER_THREADS`: Number of threads (presence enables CPU mining)
     /// - `MUJINA_CPUMINER_DUTY`: Duty cycle % (default: 50, clamped to 1-100)
     pub fn from_env() -> Option<Self> {
-        let thread_count = std::env::var("MUJINA_CPUMINER_THREADS")
+        let thread_count: usize = std::env::var("MUJINA_CPUMINER_THREADS")
             .ok()
             .and_then(|s| s.parse().ok())?;
+
+        if thread_count > MAX_THREAD_COUNT {
+            warn!(
+                requested = thread_count,
+                max = MAX_THREAD_COUNT,
+                "MUJINA_CPUMINER_THREADS clamped"
+            );
+        }
+        let thread_count = thread_count.min(MAX_THREAD_COUNT);
 
         let duty_percent = std::env::var("MUJINA_CPUMINER_DUTY")
             .ok()
@@ -81,5 +99,20 @@ mod tests {
         if let Some(config) = CpuMinerConfig::from_env() {
             assert_eq!(config.duty_percent, 1);
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_thread_count_clamped_to_max() {
+        // SAFETY: Test runs serially, no concurrent env access
+        unsafe {
+            std::env::set_var("MUJINA_CPUMINER_THREADS", "100000");
+        }
+
+        let config = CpuMinerConfig::from_env().unwrap();
+        assert_eq!(config.thread_count, MAX_THREAD_COUNT);
+
+        // SAFETY: Test runs serially, no concurrent env access
+        unsafe { std::env::remove_var("MUJINA_CPUMINER_THREADS") };
     }
 }

--- a/mujina-miner/src/scheduler.rs
+++ b/mujina-miner/src/scheduler.rs
@@ -466,9 +466,18 @@ impl Scheduler {
             debug!(source = %source_name, "No eligible threads yet, job cached for later");
             return;
         }
-        let en2_slices = full_en2_range
-            .split(eligible.len())
-            .expect("Failed to split EN2 range among threads");
+        // A range too small to give every thread its own slice means a
+        // pathological pool-advertised extranonce2 size (or an absurd
+        // thread count); skip the job rather than panic.
+        let Some(en2_slices) = full_en2_range.split(eligible.len()) else {
+            error!(
+                source = %source_name,
+                threads = eligible.len(),
+                en2_values = full_en2_range.len(),
+                "Extranonce2 space too small to split across threads; skipping job"
+            );
+            return;
+        };
 
         for (thread_id, en2_range) in eligible.into_iter().zip(en2_slices) {
             let starting_en2 = en2_range.iter().next();
@@ -1170,6 +1179,7 @@ impl MiningStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::asic::hash_thread::{HashThreadCapabilities, HashThreadStatus};
     use crate::types::Difficulty;
 
     #[test]
@@ -1301,5 +1311,122 @@ mod tests {
         gate.record_enumeration_complete();
         gate.record_timeout();
         assert!(!gate.is_holding());
+    }
+
+    /// A HashThread that accepts any task and never produces work.
+    struct StubThread {
+        name: String,
+        capabilities: HashThreadCapabilities,
+        event_rx: Option<mpsc::Receiver<HashThreadEvent>>,
+    }
+
+    impl StubThread {
+        fn new(name: String) -> Self {
+            let (_tx, rx) = mpsc::channel(1);
+            Self {
+                name,
+                capabilities: HashThreadCapabilities::default(),
+                event_rx: Some(rx),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HashThread for StubThread {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn capabilities(&self) -> &HashThreadCapabilities {
+            &self.capabilities
+        }
+
+        async fn configure(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn update_task(&mut self, _task: HashTask) -> anyhow::Result<Option<HashTask>> {
+            Ok(None)
+        }
+
+        async fn replace_task(&mut self, _task: HashTask) -> anyhow::Result<Option<HashTask>> {
+            Ok(None)
+        }
+
+        async fn go_idle(&mut self) -> anyhow::Result<Option<HashTask>> {
+            Ok(None)
+        }
+
+        fn take_event_receiver(&mut self) -> Option<mpsc::Receiver<HashThreadEvent>> {
+            self.event_rx.take()
+        }
+
+        fn status(&self) -> HashThreadStatus {
+            HashThreadStatus::default()
+        }
+    }
+
+    /// A job whose extranonce2 space is smaller than the eligible thread
+    /// count cannot be split; the scheduler must skip it, not panic.
+    #[tokio::test]
+    async fn assign_job_skips_when_en2_space_smaller_than_thread_count() {
+        use crate::job_source::{
+            Extranonce2Range, GeneralPurposeBits, MerkleRootTemplate, VersionTemplate,
+        };
+        use bitcoin::block::Version;
+        use bitcoin::hashes::Hash;
+        use bitcoin::{BlockHash, CompactTarget};
+
+        let mut scheduler = Scheduler::new();
+        let mut share_channels = ShareStream::new();
+
+        // 257 eligible threads against a 1-byte (256-value) EN2 space.
+        for i in 0..257 {
+            scheduler.threads.insert(ThreadEntry {
+                thread: Box::new(StubThread::new(format!("stub-{i}"))),
+                hashrate: HashrateEstimator::new(HASHRATE_WINDOW),
+                expected: Some(HashRate::from_megahashes(1.0)),
+            });
+        }
+
+        let (command_tx, _command_rx) = mpsc::channel(1);
+        let source_id = scheduler.sources.insert(SourceEntry {
+            name: "test".into(),
+            url: None,
+            command_tx,
+            last_job: None,
+            difficulty_alarm: DebouncedAlarm::new(HIGH_DIFFICULTY_DEBOUNCE),
+        });
+
+        let template = JobTemplate {
+            id: "job-1".into(),
+            prev_blockhash: BlockHash::all_zeros(),
+            version: VersionTemplate::new(
+                Version::from_consensus(0x20000000),
+                GeneralPurposeBits::none(),
+            )
+            .unwrap(),
+            bits: CompactTarget::from_consensus(0x1d00ffff),
+            share_target: Target::MAX,
+            time: 0,
+            merkle_root: MerkleRootKind::Computed(MerkleRootTemplate {
+                coinbase1: vec![],
+                extranonce1: vec![],
+                extranonce2_range: Extranonce2Range::new(1).unwrap(),
+                coinbase2: vec![],
+                merkle_branches: vec![],
+            }),
+        };
+
+        scheduler
+            .assign_job_to_threads(
+                AssignMode::Replace,
+                source_id,
+                template,
+                &mut share_channels,
+            )
+            .await;
+
+        assert!(scheduler.tasks.is_empty());
     }
 }

--- a/mujina-miner/src/stratum_v1/client.rs
+++ b/mujina-miner/src/stratum_v1/client.rs
@@ -333,11 +333,20 @@ impl StratumV1Client {
 
                 let extranonce2_size = arr[2].as_u64().ok_or_else(|| {
                     StratumError::InvalidMessage("extranonce2_size not a number".to_string())
-                })? as usize;
+                })?;
+
+                // Only 1-8 bytes are meaningful (see Extranonce2). Reject
+                // anything else here rather than letting a broken or
+                // hostile pool cause a silent truncation downstream.
+                if !(1..=8).contains(&extranonce2_size) {
+                    return Err(StratumError::SubscriptionFailed(format!(
+                        "extranonce2_size {extranonce2_size} outside supported range 1-8"
+                    )));
+                }
 
                 self.state = Some(ProtocolState {
                     extranonce1: extranonce1.to_string(),
-                    extranonce2_size,
+                    extranonce2_size: extranonce2_size as usize,
                     difficulty: None,
                     version_mask: authorized_mask,
                 });
@@ -1384,6 +1393,53 @@ mod tests {
                 assert_eq!(reason, "Pool returned false");
             }
             _ => panic!("Expected ShareRejected, got {:?}", event),
+        }
+    }
+
+    /// Drive `subscribe()` over a mock transport whose pool answers with
+    /// the given extranonce2_size, returning the result.
+    async fn subscribe_with_extranonce2_size(size: u64) -> (StratumResult<()>, StratumV1Client) {
+        use super::super::connection::MockTransport;
+        use serde_json::json;
+
+        let (mut client, _event_rx) = test_client();
+        let (mut transport, mut handle) = MockTransport::pair();
+
+        tokio::spawn(async move {
+            let msg = handle.recv().await;
+            handle.send(JsonRpcMessage::Response {
+                id: msg.id().unwrap(),
+                result: Some(json!([[], "aabbccdd", size])),
+                error: None,
+            });
+        });
+
+        let result = client.subscribe(&mut transport, None).await;
+        (result, client)
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_rejects_out_of_range_extranonce2_size() {
+        // 0 and 9 are invalid outright; 264 would previously truncate to
+        // 8 via `as u8` and silently mine the wrong extranonce2 space.
+        for size in [0u64, 9, 264] {
+            let (result, _) = subscribe_with_extranonce2_size(size).await;
+            assert!(
+                matches!(result, Err(StratumError::SubscriptionFailed(_))),
+                "size {size}: expected SubscriptionFailed, got {result:?}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_accepts_valid_extranonce2_size() {
+        for size in [1u64, 4, 8] {
+            let (result, client) = subscribe_with_extranonce2_size(size).await;
+            assert!(result.is_ok(), "size {size}: {result:?}");
+            assert_eq!(
+                client.state.as_ref().unwrap().extranonce2_size,
+                size as usize,
+            );
         }
     }
 }


### PR DESCRIPTION
## Problem

The pool-supplied `extranonce2_size` (from `mining.subscribe`) flowed into job construction and work splitting with two lossy/assuming steps, all reachable by a malicious pool or a MITM (the stratum transport is plaintext):

1. **`as u8` truncation** in `job_to_template`: a size of 0 or >8 made *every* job fail template conversion — the miner stayed connected but mined nothing; a value like 264 silently wrapped to 8, mining an extranonce2 space the pool never offered (all shares invalid at the pool).
2. **`expect()` on `Extranonce2Range::split`** in the scheduler: `split` returns `None` when the range holds fewer values than there are eligible threads. Pathological size (e.g. 1 byte = 256 values) + 257+ threads → the scheduler task panicked, and since nothing supervises it, mining silently halted while the API kept serving stale telemetry.
3. **Unbounded `MUJINA_CPUMINER_THREADS`** made such thread counts trivial to reach (CPU backend) and turned typos into resource problems.

Found during a source review of pool-facing input handling.

## Fix (one commit per change)

- **`fix(stratum_v1): reject out-of-range extranonce2_size at subscribe`** — accept only the 1–8 byte range `Extranonce2` supports; fail the subscription otherwise (reconnect with the usual backoff). This also makes the downstream `as u8` provably lossless.
- **`fix(scheduler): skip jobs too small to split across threads`** — replace the `expect` with a let-else that logs (source, thread count, EN2 space) and skips the job. Regression test included: 257 stub threads vs a 1-byte EN2 space.
- **`fix(cpu_miner): clamp MUJINA_CPUMINER_THREADS to 4096`** — warning on clamp; far above any real core count.

## Tests

- `test_subscribe_rejects_out_of_range_extranonce2_size` (0, 9, 264 → `SubscriptionFailed`)
- `test_subscribe_accepts_valid_extranonce2_size` (1, 4, 8 → state set)
- `assign_job_skips_when_en2_space_smaller_than_thread_count` (no panic; no tasks assigned)
- `test_thread_count_clamped_to_max`

`cargo fmt`, `cargo clippy` (no new warnings), and `cargo test` (356 passed) are green; each commit passes on its own (verified individually).