### PR TITLE
build: quiet the checks and speed up CI caching

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,13 +22,16 @@ jobs:
         with:
           just-version: "1.40.0"
 
+      - id: image
+        run: echo "tag=$(just --evaluate BUILD_TAG)" >> "$GITHUB_OUTPUT"
+
       # Reuse the build toolchain image cached by ci.yml (same
       # key); build and save it only on a miss.
       - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: image-cache
         with:
           path: /tmp/mujina-build.tar
-          key: build-image-${{ hashFiles('build.Containerfile', 'tools.just') }}
+          key: build-image-${{ steps.image.outputs.tag }}
 
       - name: Load cached build image
         if: steps.image-cache.outputs.cache-hit == 'true'
@@ -44,7 +47,7 @@ jobs:
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
           podman save -o /tmp/mujina-build.tar \
-              "mujina-build:$(just --evaluate BUILD_TAG)"
+              "mujina-build:${{ steps.image.outputs.tag }}"
 
       # File one issue per advisory. GitHub's own notice for a
       # failed scheduled run mails only whoever last edited the

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,7 +28,7 @@ jobs:
         id: image-cache
         with:
           path: /tmp/mujina-build.tar
-          key: build-image-${{ hashFiles('build.Containerfile', 'justfile') }}
+          key: build-image-${{ hashFiles('build.Containerfile', 'tools.just') }}
 
       - name: Load cached build image
         if: steps.image-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
         with:
           just-version: "1.40.0"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,20 @@ jobs:
         with:
           path: /tmp/mujina-build.tar
           key: build-image-${{ steps.image.outputs.tag }}
+          # On a key miss, fall back to the newest saved image.
+          # Useful for a PR that changes the image partway through
+          # its series: its new tag misses, while the commits from
+          # before the change still use the restored older image.
+          restore-keys: build-image-
 
+      # Test for the tar itself: cache-hit is true only on a
+      # full-key match, so gating on it would skip every fallback
+      # restore.
       - name: Load cached build image
-        if: steps.image-cache.outputs.cache-hit == 'true'
-        run: podman load -i /tmp/mujina-build.tar
+        run: |
+          if [ -f /tmp/mujina-build.tar ]; then
+              podman load -i /tmp/mujina-build.tar
+          fi
 
       # Cache compiled dependencies and downloaded crates to speed
       # up builds. The key includes the toolchain (Containerfile)
@@ -71,6 +81,9 @@ jobs:
             target
             .cache
           key: cargo-${{ hashFiles('build.Containerfile') }}-${{ hashFiles('Cargo.lock') }}
+          # A lock change builds on the previous artifacts instead
+          # of building from scratch.
+          restore-keys: cargo-${{ hashFiles('build.Containerfile') }}-
 
       - run: just ci
 
@@ -84,5 +97,8 @@ jobs:
       - name: Save build image for cache
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
+          # A fallback restore leaves the old tar behind, and
+          # podman save refuses to overwrite an archive.
+          rm -f /tmp/mujina-build.tar
           podman save -o /tmp/mujina-build.tar \
               "mujina-build:${{ steps.image.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         id: image-cache
         with:
           path: /tmp/mujina-build.tar
-          key: build-image-${{ hashFiles('build.Containerfile', 'justfile') }}
+          key: build-image-${{ hashFiles('build.Containerfile', 'tools.just') }}
 
       - name: Load cached build image
         if: steps.image-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,18 @@ jobs:
         with:
           just-version: "1.40.0"
 
+      - id: image
+        run: echo "tag=$(just --evaluate BUILD_TAG)" >> "$GITHUB_OUTPUT"
+
       # Cache the build toolchain image as a portable tar archive.
       # Podman's overlay storage can't be cached directly (tar fails
       # on overlay whiteout files), so we round-trip through podman
-      # save/load. The cache key hashes the image inputs, the same
-      # files BUILD_TAG in the justfile hashes, so that build-image
-      # recognizes the loaded image and skips the build.
+      # save/load.
       - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: image-cache
         with:
           path: /tmp/mujina-build.tar
-          key: build-image-${{ hashFiles('build.Containerfile', 'tools.just') }}
+          key: build-image-${{ steps.image.outputs.tag }}
 
       - name: Load cached build image
         if: steps.image-cache.outputs.cache-hit == 'true'
@@ -84,4 +85,4 @@ jobs:
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
           podman save -o /tmp/mujina-build.tar \
-              "mujina-build:$(just --evaluate BUILD_TAG)"
+              "mujina-build:${{ steps.image.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           # Full history so just ci can walk the branch's commits.
           fetch-depth: 0
-      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
         with:
           just-version: "1.40.0"
 

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN cargo install --locked just --version 1.40.0
 
-# Install the cargo tools the recipes use, at the versions the
-# justfile names. build.Containerfile comes along because just
-# hashes it when parsing the justfile.
+# Install the cargo tools the recipes use, at the versions
+# tools.just names. Only tools.just is copied in, so a recipe
+# edit in the justfile does not invalidate this layer.
 WORKDIR /setup
-COPY justfile build.Containerfile ./
-RUN just setup-tools
+COPY tools.just ./
+RUN just --justfile tools.just setup-tools
 
 WORKDIR /workspace

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,10 @@ allow = [
 # Refuse wildcard version requirements. Every dependency must
 # name a range.
 wildcards = "deny"
+# Duplicate crate versions arise when dependencies require
+# incompatible versions of a shared crate. Not actionable, so
+# don't warn. Use `cargo tree -d` to list them.
+multiple-versions = "allow"
 
 [sources]
 # Every dependency must come from crates.io.

--- a/deny.toml
+++ b/deny.toml
@@ -25,6 +25,19 @@ allow = [
     "Zlib",
 ]
 
+# unescaper declares "GPL-3.0/MIT", the pre-SPDX-2.0 slash form,
+# which cargo-deny cannot parse and warns about. State the
+# expression in valid SPDX. The hashes fix the crate's license
+# files, so a licensing change upstream fails the check instead
+# of passing silently. Delete when upstream fixes its metadata.
+[[licenses.clarify]]
+crate = "unescaper"
+expression = "GPL-3.0-only OR MIT"
+license-files = [
+    { path = "LICENSE-GPL3", hash = 0xe497def1 },
+    { path = "LICENSE-MIT", hash = 0xeb164a42 },
+]
+
 [bans]
 # Refuse wildcard version requirements. Every dependency must
 # name a range.

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+import 'tools.just'
+
 _default:
     @just --list --unsorted
 
@@ -48,13 +50,15 @@ _require tool:
         exit 1; }
 
 BUILD_IMAGE := "mujina-build"
+# These files decide the build toolchain image's content. tools.just
+# qualifies because the image runs setup-tools from it.
+IMAGE_INPUTS := "build.Containerfile tools.just"
 # Tag with a content hash of the image inputs so we can detect
 # staleness without rebuilding. This matters in CI where podman
 # save/load doesn't preserve layer cache---podman build would
 # rebuild from scratch even with a loaded image. The content-hash
-# tag lets `podman image exists` skip the build entirely. The
-# justfile is an input because the image runs setup-tools.
-BUILD_TAG := `sha256sum build.Containerfile justfile | sha256sum | cut -c1-12`
+# tag lets `podman image exists` skip the build entirely.
+BUILD_TAG := shell('sha256sum ' + IMAGE_INPUTS + ' | sha256sum | cut -c1-12')
 
 # Build the build toolchain image (skips if unchanged)
 [group('container')]
@@ -131,21 +135,3 @@ setup-hooks:
     git config core.hooksPath .githooks
     @echo "Git hooks configured to use .githooks/"
     @ls .githooks/ | sed 's/^/  - /'
-
-# Install the cargo tools the recipes use. The recipe installs a
-# missing tool at the exact version named here, and leaves a tool
-# already on PATH alone, at whatever version it is. The build
-# container runs this recipe, so these versions decide what runs
-# in CI.
-[group('setup')]
-setup-tools:
-    @if command -v cargo-cooldown >/dev/null; then \
-        echo "cargo-cooldown already installed; using the system copy"; \
-    else \
-        cargo install --locked cargo-cooldown --version 0.3.4; \
-    fi
-    @if command -v cargo-deny >/dev/null; then \
-        echo "cargo-deny already installed; using the system copy"; \
-    else \
-        cargo install --locked cargo-deny --version 0.20.2; \
-    fi

--- a/tools.just
+++ b/tools.just
@@ -1,0 +1,21 @@
+# Cargo tool installation, imported by the justfile and build container.
+#
+# setup-tools installs a missing tool if it is not already installed. The build
+# container runs this recipe, so these versions decide what runs in CI.
+
+COOLDOWN_VERSION := "0.3.4"
+DENY_VERSION := "0.20.2"
+
+# Install the cargo tools the recipes use
+[group('setup')]
+setup-tools:
+    @if command -v cargo-cooldown >/dev/null; then \
+        echo "cargo-cooldown already installed; using the system copy"; \
+    else \
+        cargo install --locked cargo-cooldown --version {{COOLDOWN_VERSION}}; \
+    fi
+    @if command -v cargo-deny >/dev/null; then \
+        echo "cargo-deny already installed; using the system copy"; \
+    else \
+        cargo install --locked cargo-deny --version {{DENY_VERSION}}; \
+    fi


### PR DESCRIPTION
Fixes from auditing the supply-chain hardening's first CI run (PR #91).

- `just checks` now runs warning-free: allow cargo's duplicate crate versions (not actionable) and clarify unescaper's unparseable license declaration.
- The build toolchain image rebuilds only when a tool changes: tool setup moves to tools.just, the only file the container copies, and the CI cache key comes from the justfile's BUILD_TAG, so the key and the image tag cannot drift.
- On a cache key miss, restore-keys falls back to the nearest saved cache instead of starting cold.
- setup-just v4 retires GitHub's Node 20 deprecation warning.
