### PR TITLE
fix: reject unparseable job coinbases instead of idling silently

### DIFF
--- a/mujina-miner/src/cpu_miner/hasher.rs
+++ b/mujina-miner/src/cpu_miner/hasher.rs
@@ -286,7 +286,18 @@ fn compute_merkle_root(task: &HashTask) -> Option<bitcoin::TxMerkleNode> {
         MerkleRootKind::Fixed(mr) => Some(*mr),
         MerkleRootKind::Computed(_) => {
             let en2 = task.en2.as_ref()?;
-            template.compute_merkle_root(en2).ok()
+            let root = template.compute_merkle_root(en2);
+            if root.is_err() {
+                // Without a merkle root the task cannot be mined; say so
+                // loudly instead of idling in silence. Jobs from the
+                // stratum source are validated upstream, so this should
+                // be rare.
+                warn!(
+                    job_id = %template.id,
+                    "Job coinbase does not parse; task cannot be mined"
+                );
+            }
+            root.ok()
         }
     }
 }
@@ -330,7 +341,10 @@ fn update_status(status: &Arc<RwLock<HashThreadStatus>>, is_active: bool, shares
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::job_source::{GeneralPurposeBits, JobTemplate, MerkleRootKind, VersionTemplate};
+    use crate::job_source::{
+        Extranonce2, Extranonce2Range, GeneralPurposeBits, JobTemplate, MerkleRootKind,
+        MerkleRootTemplate, VersionTemplate,
+    };
     use bitcoin::hashes::Hash;
     use bitcoin::pow::Target;
     use std::sync::Arc;
@@ -376,6 +390,51 @@ mod tests {
     fn probe_measures_a_positive_rate() {
         let rate = probe_peak_hashrate_for(Duration::from_millis(20));
         assert!(!rate.is_zero(), "probe should observe some hashing");
+    }
+
+    /// Build a task with a Computed merkle root from raw coinbase halves.
+    fn make_computed_task(coinbase1: Vec<u8>, coinbase2: Vec<u8>) -> HashTask {
+        let task = make_test_task();
+        let template = Arc::new(JobTemplate {
+            merkle_root: MerkleRootKind::Computed(MerkleRootTemplate {
+                coinbase1,
+                extranonce1: vec![0xab, 0xcd, 0xef, 0x01],
+                extranonce2_range: Extranonce2Range::new(4).unwrap(),
+                coinbase2,
+                merkle_branches: vec![],
+            }),
+            ..task.template.as_ref().clone()
+        });
+        HashTask {
+            template,
+            en2: Some(Extranonce2::new(0, 4).unwrap()),
+            ..task
+        }
+    }
+
+    #[test]
+    fn unparseable_coinbase_yields_no_merkle_root() {
+        // A coinbase that hex-decodes but doesn't form a transaction
+        // can't be mined; compute_merkle_root reports None (and warns).
+        let task = make_computed_task(vec![0xaa], vec![0xbb]);
+        assert!(compute_merkle_root(&task).is_none());
+    }
+
+    #[test]
+    fn valid_coinbase_yields_merkle_root() {
+        // version(4) vin_count(1) prevhash(32) index(4) scriptlen(8) ||
+        // sequence(4) vout_count(1) locktime(4): a structure-valid
+        // 1-in/0-out transaction once the extranonces (4+4 bytes) are
+        // spliced in as the scriptSig.
+        let mut coinbase1 = hex::decode("02000000").unwrap();
+        coinbase1.push(0x01);
+        coinbase1.extend_from_slice(&[0x00; 32]);
+        coinbase1.extend_from_slice(&[0xff; 4]);
+        coinbase1.push(0x08);
+        let coinbase2 = hex::decode("ffffffff0000000000").unwrap();
+
+        let task = make_computed_task(coinbase1, coinbase2);
+        assert!(compute_merkle_root(&task).is_some());
     }
 
     #[test]

--- a/mujina-miner/src/job_source/stratum_v1.rs
+++ b/mujina-miner/src/job_source/stratum_v1.rs
@@ -21,8 +21,8 @@ use crate::tracing::prelude::*;
 use crate::types::{Difficulty, HashRate, ShareRate};
 
 use super::{
-    Extranonce2Range, GeneralPurposeBits, JobTemplate, MerkleRootKind, MerkleRootTemplate, Share,
-    SourceCommand, SourceEvent, VersionTemplate,
+    Extranonce2, Extranonce2Range, GeneralPurposeBits, JobTemplate, MerkleRootKind,
+    MerkleRootTemplate, Share, SourceCommand, SourceEvent, VersionTemplate,
 };
 
 /// Target share rate for suggest_difficulty: 20 shares/min (one every 3 sec).
@@ -243,6 +243,24 @@ impl StratumV1Source {
         let share_difficulty = state.share_difficulty.unwrap_or(Difficulty::from(1));
         let share_target = share_difficulty.to_target();
 
+        let merkle_root = MerkleRootKind::Computed(MerkleRootTemplate {
+            coinbase1: job.coinbase1,
+            extranonce1: state.extranonce1.clone(),
+            extranonce2_range,
+            coinbase2: job.coinbase2,
+            merkle_branches: job.merkle_branches,
+        });
+
+        // A coinbase that doesn't deserialize can never produce a valid
+        // merkle root, and threads that discover that on assignment fail
+        // silently. Reject the job here, where the error is visible.
+        if let MerkleRootKind::Computed(template) = &merkle_root {
+            let probe = Extranonce2::new(0, state.extranonce2_size as u8)?;
+            template
+                .compute_merkle_root(&probe)
+                .map_err(|e| anyhow::anyhow!("job coinbase does not parse: {e}"))?;
+        }
+
         Ok(JobTemplate {
             id: job.job_id,
             prev_blockhash: job.prev_hash,
@@ -250,13 +268,7 @@ impl StratumV1Source {
             bits: job.nbits,
             share_target,
             time: job.ntime,
-            merkle_root: MerkleRootKind::Computed(MerkleRootTemplate {
-                coinbase1: job.coinbase1,
-                extranonce1: state.extranonce1.clone(),
-                extranonce2_range,
-                coinbase2: job.coinbase2,
-                merkle_branches: job.merkle_branches,
-            }),
+            merkle_root,
         })
     }
 
@@ -929,11 +941,15 @@ mod tests {
             None, // No version rolling
         );
 
+        // Coinbase halves that assemble with STRATUM_EXTRANONCE1 (4
+        // bytes) + 4 bytes of extranonce2 into a structure-valid
+        // 1-in/0-out transaction, as job_to_template now rejects
+        // coinbases that don't parse.
         let params = json!([
             "jobid",
             "0000000000000000000000000000000000000000000000000000000000000000",
-            "aa",
-            "bb",
+            format!("02000000{}{}ffffffff08", "01", "00".repeat(32)),
+            "ffffffff0000000000",
             [],
             "20000000",
             "1d00ffff",
@@ -964,11 +980,15 @@ mod tests {
             Some(VERSION_MASK),
         );
 
+        // Coinbase halves that assemble with STRATUM_EXTRANONCE1 (4
+        // bytes) + 4 bytes of extranonce2 into a structure-valid
+        // 1-in/0-out transaction, as job_to_template now rejects
+        // coinbases that don't parse.
         let params = json!([
             "jobid",
             "0000000000000000000000000000000000000000000000000000000000000000",
-            "aa",
-            "bb",
+            format!("02000000{}{}ffffffff08", "01", "00".repeat(32)),
+            "ffffffff0000000000",
             [],
             "20000000",
             "1d00ffff",
@@ -986,6 +1006,67 @@ mod tests {
             "Default difficulty should be ~1, got {}",
             share_difficulty_float
         );
+    }
+
+    /// A coinbase that hex-decodes but doesn't form a transaction must
+    /// fail template conversion, not reach the hash threads.
+    #[test]
+    fn test_job_to_template_rejects_unparseable_coinbase() {
+        let extranonce1 = hex::decode(STRATUM_EXTRANONCE1).unwrap();
+        let source = source_with_state(
+            extranonce1,
+            STRATUM_EXTRANONCE2_SIZE,
+            Some(POOL_SHARE_DIFFICULTY_INT),
+            Some(VERSION_MASK),
+        );
+
+        let params = json!([
+            "jobid",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "aa",
+            "bb",
+            [],
+            "20000000",
+            "1d00ffff",
+            "5a5a5a5a",
+            false
+        ]);
+
+        let job = JobNotification::from_stratum_params(params.as_array().unwrap()).unwrap();
+        let result = source.job_to_template(job);
+        assert!(
+            matches!(&result, Err(e) if e.to_string().contains("coinbase")),
+            "expected coinbase parse error, got {result:?}",
+        );
+    }
+
+    /// The structure-valid coinbase used by the other tests passes the
+    /// parse check and yields a Computed merkle template.
+    #[test]
+    fn test_job_to_template_accepts_valid_coinbase() {
+        let extranonce1 = hex::decode(STRATUM_EXTRANONCE1).unwrap();
+        let source = source_with_state(
+            extranonce1,
+            STRATUM_EXTRANONCE2_SIZE,
+            Some(POOL_SHARE_DIFFICULTY_INT),
+            Some(VERSION_MASK),
+        );
+
+        let params = json!([
+            "jobid",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            format!("02000000{}{}ffffffff08", "01", "00".repeat(32)),
+            "ffffffff0000000000",
+            [],
+            "20000000",
+            "1d00ffff",
+            "5a5a5a5a",
+            false
+        ]);
+
+        let job = JobNotification::from_stratum_params(params.as_array().unwrap()).unwrap();
+        let template = source.job_to_template(job).unwrap();
+        assert!(matches!(template.merkle_root, MerkleRootKind::Computed(_)));
     }
 
     /// Test share_to_submit_params with real capture data.
@@ -1594,14 +1675,22 @@ mod tests {
     }
 
     /// Build a minimal mining.notify notification.
+    ///
+    /// The coinbase halves assemble with the extranonces from
+    /// `do_configure_and_subscribe` ("aabb" = 2 bytes + 4 bytes of
+    /// extranonce2) into a structure-valid 1-in/0-out transaction, as
+    /// job_to_template now rejects coinbases that don't parse.
     fn job_notification(job_id: &str) -> JsonRpcMessage {
+        // version(4) vin_count(1) prevhash(32) index(4) scriptlen(6) || sequence(4) vout_count(1) locktime(4)
+        let coinb1 = format!("02000000{}{}ffffffff06", "01", "00".repeat(32));
+        let coinb2 = "ffffffff0000000000";
         JsonRpcMessage::notification(
             "mining.notify",
             json!([
                 job_id,
                 "0000000000000000000000000000000000000000000000000000000000000000",
-                "aa",
-                "bb",
+                coinb1,
+                coinb2,
                 [],
                 "20000000",
                 "1d00ffff",


### PR DESCRIPTION
## Problem

A `mining.notify` whose `coinb1`/`coinb2` hex-decode fine (passing the job parser) but do not form a deserializable transaction is accepted and assigned to hash threads. The CPU backend's merkle computation then fails **silently**: the task is installed with no cached merkle root, the hasher spins its duty loop doing nothing, and no message at any log level names the cause. A malicious pool or stratum MITM (the transport is plaintext) can pin a miner in this looks-alive-but-idle state indefinitely — API up, pool connected, jobs arriving, zero shares.

Found during hostile-pool fuzzing (stratum-v1 battery with dummy coinbases): every pool-fed run produced zero shares and zero diagnostics, while the dummy (fixed-merkle) source mined fine.

## Fix (one commit per change)

- **`fix(job_source): reject jobs whose coinbase does not parse`** — probe the merkle computation once at template conversion; on failure the job is rejected with a visible error through the existing per-job error path (warn-and-continue, same as an invalid extranonce2 size). Test fixtures that unknowingly used unparseable coinbases (`"aa"`/`"bb"` — which is how the gap stayed invisible) now assemble a structure-valid 1-in/0-out transaction. New tests: bad coinbase rejected, valid coinbase accepted.
- **`fix(cpu_miner): warn when a task's coinbase cannot be mined`** — the hasher now warns once per offending task instead of idling silently, so any current or future job path that bypasses validation still leaves a trace. Contract tests: unparseable coinbase yields `None`, valid coinbase yields a root.

## Tests

`cargo fmt`, `cargo clippy` (no new warnings), `cargo test` (361 passed) green; each commit passes on its own. Dynamic A/B before/after on a local CPU-backend daemon: invalid coinbase → `shares=0` with zero diagnostics (before) → job rejected with `job coinbase does not parse` warning (after); valid coinbase → shares flow in both.