### PR TITLE
fix(stratum_v1): retry authorization failures instead of giving up

### DIFF
--- a/mujina-miner/src/job_source/stratum_v1.rs
+++ b/mujina-miner/src/job_source/stratum_v1.rs
@@ -1860,11 +1860,13 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn fatal_error_stops_retrying() {
+    async fn authorization_failure_retries() {
         let (source, _event_rx, command_tx, mock_tx, _shutdown) = source_with_mock_transports();
 
-        let (transport, mut handle) = MockTransport::pair();
-        mock_tx.send(transport).await.unwrap();
+        let (transport1, mut handle1) = MockTransport::pair();
+        let (transport2, mut handle2) = MockTransport::pair();
+        mock_tx.send(transport1).await.unwrap();
+        mock_tx.send(transport2).await.unwrap();
 
         let source_handle = tokio::spawn(source.run());
 
@@ -1875,19 +1877,26 @@ mod tests {
             .await
             .unwrap();
 
-        do_configure_and_subscribe(&mut handle).await;
+        do_configure_and_subscribe(&mut handle1).await;
 
-        // mining.authorize -- reject
-        let msg = handle.recv().await;
-        handle.send(JsonRpcMessage::Response {
+        // mining.authorize -- rejected. Not fatal: the source backs off
+        // and tries again instead of exiting.
+        let msg = handle1.recv().await;
+        handle1.send(JsonRpcMessage::Response {
             id: msg.id().unwrap(),
             result: Some(json!(false)),
             error: None,
         });
 
-        // Source should return Err (fatal, no reconnect).
-        let result = source_handle.await.unwrap();
-        assert!(result.is_err(), "expected fatal error, got Ok");
+        // Advance past the backoff; a second connection must arrive.
+        // The timeout turns "no retry" into a clean test failure
+        // instead of a hang.
+        time::advance(Duration::from_secs(2)).await;
+        time::timeout(Duration::from_secs(5), do_handshake(&mut handle2))
+            .await
+            .expect("source must reconnect after an authorization failure");
+
+        drop(source_handle);
     }
 
     #[tokio::test(start_paused = true)]

--- a/mujina-miner/src/stratum_v1/error.rs
+++ b/mujina-miner/src/stratum_v1/error.rs
@@ -64,17 +64,29 @@ pub enum StratumError {
 impl StratumError {
     /// Whether this error is unrecoverable and should not be retried.
     ///
-    /// Authorization failures and invalid URLs are fatal---wrong
-    /// credentials and malformed addresses won't fix themselves.
-    /// Everything else (network errors, timeouts, subscription
-    /// failures from overloaded pools) may resolve on retry.
+    /// Only invalid URLs are fatal---a malformed address won't fix
+    /// itself. Everything else, including authorization failures, is
+    /// retried with backoff: stratum is unencrypted, so a "rejected"
+    /// authorize may come from a MITM or a transient pool error rather
+    /// than from truly wrong credentials, and giving up would let a
+    /// single forged packet halt mining until a manual restart.
     pub fn is_fatal(&self) -> bool {
-        matches!(
-            self,
-            StratumError::AuthorizationFailed(_) | StratumError::InvalidUrl(_)
-        )
+        matches!(self, StratumError::InvalidUrl(_))
     }
 }
 
 /// Convenient Result type for Stratum operations.
 pub type StratumResult<T> = Result<T, StratumError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_invalid_urls_are_fatal() {
+        assert!(StratumError::InvalidUrl("x".into()).is_fatal());
+        assert!(!StratumError::AuthorizationFailed("x".into()).is_fatal());
+        assert!(!StratumError::Disconnected.is_fatal());
+        assert!(!StratumError::Timeout.is_fatal());
+    }
+}


### PR DESCRIPTION
## Problem

`AuthorizationFailed` was one of only two fatal errors in the stratum stack: a pool that answers `mining.authorize` with an error (or `result: false`) made the source task exit **permanently** — no retry, no backoff, no process exit, no API alarm. The daemon stays alive (API serving, boards registered) but never mines again until manually restarted.

Because stratum v1 is plaintext, an on-path attacker who sees the `mining.authorize` request can race the real pool with a forged error response and stop a miner — or a whole fleet — with a single packet. Worse than a crash: `systemd`/`Restart=always` sees a healthy process, so only hashrate monitoring notices.

Found during hostile-pool fuzzing (handshake-variant battery): after one auth-error response the miner made zero further connection attempts for the rest of the run while `Mining status` heartbeats continued.

## Fix

Remove `AuthorizationFailed` from `is_fatal()`; auth failures now take the same jittered exponential backoff reconnect path as any other disconnect. Truly wrong credentials cost a reconnect a minute and a repeating log line; forged or transient rejections no longer halt production. `InvalidUrl` stays fatal — a malformed address genuinely won't fix itself.

## Tests

- `authorization_failure_retries` (replaces `fatal_error_stops_retrying`): auth-rejected source must produce a second connection after the backoff window; a timeout turns "no retry" into a clean failure instead of a hang.
- `only_invalid_urls_are_fatal` (new error.rs unit test): pins the remaining fatal set.

`cargo fmt`, `cargo clippy` (no new warnings), `cargo test` (358 passed) green.