### PR TITLE
chore(deps): update h2 to 0.4.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

Updates the transitive `h2` dependency from 0.4.15 to 0.4.19 to
resolve RUSTSEC-2026-0258.

The update was performed with the project's dependency tooling after
the seven-day dependency cooldown expired.

## Exposure

The vulnerable HTTP/2 path is not reached in Mujina's default setup.
The REST API server speaks HTTP/1, while the CLI can negotiate HTTP/2
when pointed at an HTTPS URL. Mining pool connections use Stratum over
raw TCP and are unaffected.

## Verification

- reproduced RUSTSEC-2026-0258 with `just audit` before the update
- updated `h2` using `just update-deps h2`
- `just audit` passes after the update
- `just checks` passes
- `git diff --check` passes

`just ci` was not run locally because Podman is not installed.

Closes #101