### PR TITLE
build(deps): use cargo's own min-publish-age and gate PRs on it

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# Dependency cooldown. A version published less than this long ago
+# may not enter Cargo.lock. Most malicious crate releases are caught
+# and yanked within days. scripts/check-dep-cooldown enforces it on
+# pull requests; cargo itself enforces it from version 1.100 forward.
+[registry]
+global-min-publish-age = "7 days"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
-# Dependency cooldown. A version published less than this long ago
-# may not enter Cargo.lock. Most malicious crate releases are caught
-# and yanked within days. scripts/check-dep-cooldown enforces it on
-# pull requests; cargo itself enforces it from version 1.100 forward.
+[unstable]
+min-publish-age = true
+
 [registry]
+# Dependency cooldown. Cargo enforces it in v1.100; until then the unstable
+# table turns it on in the nightly toolchain.
 global-min-publish-age = "7 days"

--- a/.github/workflows/check-dep-cooldown.yml
+++ b/.github/workflows/check-dep-cooldown.yml
@@ -1,0 +1,54 @@
+# Fail a pull request that adds a crates.io version younger than the
+# cooldown in .cargo/config.toml. The recipe fetches the locked crates
+# and compiles nothing.
+
+name: Check dep cooldown
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - .cargo/config.toml
+      - scripts/check-dep-cooldown
+      - .github/workflows/check-dep-cooldown.yml
+
+permissions:
+  contents: read
+
+jobs:
+  check-dep-cooldown:
+    name: just check-dep-cooldown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # The base branch's Cargo.lock is the point of comparison.
+          fetch-depth: 0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: "1.40.0"
+
+      - id: image
+        run: echo "tag=$(just --evaluate BUILD_TAG)" >> "$GITHUB_OUTPUT"
+
+      # Reuse the build toolchain image cached by ci.yml (same
+      # key); build and save it only on a miss.
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        id: image-cache
+        with:
+          path: /tmp/mujina-build.tar
+          key: build-image-${{ steps.image.outputs.tag }}
+
+      - name: Load cached build image
+        if: steps.image-cache.outputs.cache-hit == 'true'
+        run: podman load -i /tmp/mujina-build.tar
+
+      - env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: just in-container check-dep-cooldown "$BASE_REF"
+
+      - name: Save build image for cache
+        if: steps.image-cache.outputs.cache-hit != 'true'
+        run: |
+          podman save -o /tmp/mujina-build.tar \
+              "mujina-build:${{ steps.image.outputs.tag }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /.cache/
+__pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,19 +178,39 @@ just in-container checks
 
 ### Updating Dependencies
 
-Dependency versions are locked in `Cargo.lock`, and every build
-passes `--locked`, so versions change only deliberately.
+To mitigate supply-chain attacks, the project holds every crate
+release back for several days before it may enter `Cargo.lock` (the
+age is set in `.cargo/config.toml`). The Rust community catches and
+yanks most malicious releases within hours or days of publication.
 
-After editing `Cargo.toml` (adding, removing, or re-ranging a
-dependency), run:
+Dependency versions are locked in `Cargo.lock`. Pass `--locked` to
+cargo so a build never rewrites the lock as a side effect. The just
+recipes and CI pass `--locked` on every cargo call.
+
+After editing `Cargo.toml` to add, remove, or re-range a
+dependency, update the lockfile through the just recipes, which
+honor the cooldown.
 
 ```bash
 just resolve-deps
 ```
 
-This picks versions for the dependencies you changed, writes
-them to `Cargo.lock`, and leaves every other locked version
-unchanged.
+`resolve-deps` picks appropriate versions for the dependencies you
+changed, writes them to `Cargo.lock`, and leaves every other locked
+version unchanged.
+
+Review the `Cargo.lock` diff and commit it like any other change.
+`just check-dep-cooldown` fails if a dependency introduced since a
+base ref, `origin/main` by default, is too young. A CI job runs
+that check against the base branch. When an underage version must
+go in, such as a security fix that cannot wait, a maintainer
+merges despite the failed CI job.
+
+Cargo's min-publish-age setting is unstable until cargo 1.100. Until
+it ships, only the nightly toolchain enforces the age, so the just
+recipes which edit dependencies run `cargo +nightly`. Stable cargo
+ignores the setting without a warning, so a plain `cargo add` or
+`cargo update` picks young versions.
 
 To refresh all dependencies to the newest allowed versions:
 
@@ -198,14 +218,17 @@ To refresh all dependencies to the newest allowed versions:
 just update-deps
 ```
 
-Both commands refuse versions published less than seven days ago
-and automatically pick the newest older version instead (the
-cooldown in `cooldown.toml`). The cooldown defends against
-supply-chain attacks. Most malicious crate releases are caught
-and yanked within days of publication, and the wait keeps them
-out of `Cargo.lock`.
+To move one crate to its newest allowed version and nothing else:
 
-Review the `Cargo.lock` diff and commit it like any other change.
+```bash
+just update-dep h2
+```
+
+To move one crate to a version that violates the cooldown:
+
+```bash
+just force-dep h2 0.4.16
+```
 
 ### Documenting Known Bugs with `#[should_panic]`
 

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,7 +1,0 @@
-# Dependency update cooldown, enforced by cargo-cooldown. Refuse
-# versions younger than the age below; most malicious crate
-# releases are caught and yanked within days. The key name
-# follows cargo RFC 3923. When cargo implements the RFC, drop
-# the wrapper and move this setting into .cargo/config.toml.
-[registry]
-global-min-publish-age = "7 days"

--- a/justfile
+++ b/justfile
@@ -25,9 +25,14 @@ deny: (_require "cargo-deny")
 audit: (_require "cargo-deny")
     cargo deny --locked check advisories
 
+# Run the unit tests of the Python scripts
+[group('dev')]
+test-scripts:
+    python3 -B -m unittest discover -s scripts -p '*_test.py'
+
 # Run all checks (before commit, push, merge, release)
 [group('dev')]
-@checks: (fmt "--check") lint test deny
+@checks: (fmt "--check") lint test-scripts deny test
 
 [group('dev')]
 run:
@@ -50,6 +55,16 @@ update-deps *crates: (_require "cargo-cooldown")
 [group('deps')]
 resolve-deps: (_require "cargo-cooldown")
     cargo cooldown check
+
+# The fetch resolves the lock, which fills cargo's index cache, where
+# the check reads publish times. With the crates already fetched it
+# does nothing and needs no network.
+#
+# Fail if Cargo.lock gained a crates.io version younger than the cooldown
+[group('deps')]
+check-dep-cooldown base='origin/main':
+    cargo fetch --locked
+    scripts/check-dep-cooldown {{base}}
 
 [private]
 _require tool:
@@ -82,6 +97,9 @@ build-image-clean:
         | grep -v ':{{BUILD_TAG}}$' \
         | xargs -r podman rmi
 
+# The git config marks the mounted workspace as trusted, since git
+# refuses a repository owned by another user.
+#
 # Run a just recipe inside the build toolchain image
 [group('container')]
 in-container *args: build-image
@@ -91,6 +109,9 @@ in-container *args: build-image
         -v "$(pwd)/.cache/cargo-registry":/usr/local/cargo/registry \
         -v "$(pwd)/.cache/cargo-git":/usr/local/cargo/git \
         -w /workspace \
+        -e GIT_CONFIG_COUNT=1 \
+        -e GIT_CONFIG_KEY_0=safe.directory \
+        -e GIT_CONFIG_VALUE_0=/workspace \
         {{BUILD_IMAGE}}:{{BUILD_TAG}} \
         just {{args}}
 

--- a/justfile
+++ b/justfile
@@ -47,15 +47,35 @@ run:
 test-bitaxe-gamma tier='smoke':
     cargo test --locked --test bitaxe_gamma -- --ignored --nocapture --test-threads=1 {{tier}}
 
-# Update all dependencies, or only the named crates, to aged versions
+# Dependency edits use the nightly toolchain until cargo 1.100
+# enforces the cooldown in .cargo/config.toml on stable.
+CARGO_DEPS := "cargo +nightly"
+
+# Update all dependencies to their newest allowed versions
 [group('deps')]
-update-deps *crates: (_require "cargo-cooldown")
-    cargo cooldown update {{ prepend("-p ", crates) }}
+update-deps:
+    {{CARGO_DEPS}} update
+
+# The single-crate recipes that follow edit the crate's lock entry and let
+# cargo re-resolve it. The direct way, `cargo update -p`, also rewrites
+# unrelated entries to older versions (rust-lang/cargo#5529).
+
+# Update one crate to its newest allowed version; nothing else moves
+[group('deps')]
+update-dep crate:
+    scripts/lock-edit drop {{crate}}
+    {{CARGO_DEPS}} update --workspace
+
+# Move one crate to an exact version, even inside the cooldown
+[group('deps')]
+force-dep crate version:
+    scripts/lock-edit set {{crate}} {{version}}
+    CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow {{CARGO_DEPS}} update --workspace
 
 # Bring Cargo.lock in line with Cargo.toml after a manifest edit
 [group('deps')]
-resolve-deps: (_require "cargo-cooldown")
-    cargo cooldown check
+resolve-deps:
+    {{CARGO_DEPS}} update --workspace
 
 # The fetch resolves the lock, which fills cargo's index cache, where
 # the check reads publish times. With the crates already fetched it

--- a/justfile
+++ b/justfile
@@ -38,10 +38,11 @@ test-scripts:
 run:
     cargo run --locked --bin mujina-minerd
 
-# Quick mining check on an attached Bitaxe Gamma; pass "baseline" for
-# the full check with the hashrate band; needs the board powered;
-# set MUJINA_POOL_URL/MUJINA_POOL_USER to mine to a pool, or leave
-# them unset to mine to the daemon's dummy source
+# Pass "baseline" for the full check with the hashrate band. Needs
+# the board powered. Set MUJINA_POOL_URL/MUJINA_POOL_USER to mine to
+# a pool, or leave them unset to mine to the daemon's dummy source.
+#
+# Quick mining check on an attached Bitaxe Gamma
 [group('hw')]
 test-bitaxe-gamma tier='smoke':
     cargo test --locked --test bitaxe_gamma -- --ignored --nocapture --test-threads=1 {{tier}}

--- a/scripts/check-dep-cooldown
+++ b/scripts/check-dep-cooldown
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Fail when Cargo.lock holds a crates.io version younger than the cooldown.
+
+    check-dep-cooldown [BASE_REF]
+
+With BASE_REF, only versions absent from that ref's Cargo.lock are
+checked, so a pull request fails exactly when it adds a too-young
+version. Without it, every crates.io version in the lock is checked.
+
+The cooldown is registry.global-min-publish-age in .cargo/config.toml.
+Publish times come from cargo's local index cache, which cargo fills
+whenever it resolves the lock, so the check needs no network and
+never uses it. A version missing from the cache fails the check;
+`cargo fetch --locked` fills the cache, and the just recipe runs it
+first.
+"""
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+CRATES_IO = "registry+https://github.com/rust-lang/crates.io-index"
+CONFIG = Path(".cargo/config.toml")
+LOCK = Path("Cargo.lock")
+FILL_HINT = "run `cargo fetch --locked` to fill the index cache"
+
+
+def main(argv):
+    if len(argv) > 2:
+        sys.exit(__doc__.strip())
+    base_ref = argv[1] if len(argv) == 2 else None
+    added, problems = check(base_ref, datetime.now(timezone.utc))
+    for problem in problems:
+        print(f"error: {problem}")
+    scope = f"added since {base_ref}" if base_ref else "in Cargo.lock"
+    print(
+        f"checked {len(added)} crates.io versions {scope}; "
+        f"{len(problems)} too young or unknown"
+    )
+    sys.exit(1 if problems else 0)
+
+
+def check(base_ref, now):
+    """Return the versions checked and one problem line per failing version."""
+    window = cooldown()
+    added = sorted(
+        packages(LOCK.read_text())
+        - (packages(base_lock(base_ref)) if base_ref else set())
+    )
+    problems = []
+    for name, version in added:
+        published = pubtime(name, version)
+        if published is None:
+            problems.append(
+                f"{name} {version}: not in the local index cache; {FILL_HINT}"
+            )
+        elif now - published < window:
+            age = now - published
+            problems.append(
+                f"{name} {version}: published {published.isoformat()}, "
+                f"{age.days} days old, cooldown is {window.days} days"
+            )
+    return added, problems
+
+
+def cooldown():
+    config = tomllib.loads(CONFIG.read_text())
+    text = config["registry"]["global-min-publish-age"]
+    match = re.fullmatch(r"(\d+)\s*(second|minute|hour|day)s?", text.strip())
+    if not match:
+        sys.exit(f"error: cannot parse global-min-publish-age {text!r} in {CONFIG}")
+    return timedelta(**{match.group(2) + "s": int(match.group(1))})
+
+
+def packages(lock_text):
+    lock = tomllib.loads(lock_text)
+    return {
+        (p["name"], p["version"])
+        for p in lock.get("package", [])
+        if p.get("source") == CRATES_IO
+    }
+
+
+def base_lock(ref):
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{LOCK}"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        sys.exit(f"error: cannot read {LOCK} at {ref}: {result.stderr.strip()}")
+    return result.stdout
+
+
+def pubtime(name, version):
+    """The version's publish time from cargo's sparse index cache, or None."""
+    for path in glob.glob(
+        os.path.join(
+            cargo_home(), "registry/index/index.crates.io-*/.cache", index_path(name)
+        )
+    ):
+        # Five header bytes, then NUL-separated fields: an etag, then
+        # version and JSON pairs.
+        fields = Path(path).read_bytes()[5:].split(b"\0")
+        for i in range(1, len(fields) - 1, 2):
+            if fields[i].decode() == version:
+                stamp = json.loads(fields[i + 1]).get("pubtime")
+                return (
+                    datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+                    if stamp
+                    else None
+                )
+    return None
+
+
+def cargo_home():
+    return os.environ.get("CARGO_HOME") or os.path.expanduser("~/.cargo")
+
+
+def index_path(name):
+    name = name.lower()
+    if len(name) == 1:
+        return f"1/{name}"
+    if len(name) == 2:
+        return f"2/{name}"
+    if len(name) == 3:
+        return f"3/{name[0]}/{name}"
+    return f"{name[:2]}/{name[2:4]}/{name}"
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/check_dep_cooldown_test.py
+++ b/scripts/check_dep_cooldown_test.py
@@ -1,0 +1,187 @@
+"""Unit tests for check-dep-cooldown. Run with python3 -m unittest."""
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("check-dep-cooldown")
+CRATES_IO = "registry+https://github.com/rust-lang/crates.io-index"
+NOW = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def load_script():
+    loader = importlib.machinery.SourceFileLoader("check_dep_cooldown", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+check_dep_cooldown = load_script()
+
+
+def lock_text(*packages):
+    """A Cargo.lock holding (name, version, source) entries; source None is a path."""
+    text = "version = 4\n\n"
+    for name, version, source in packages:
+        text += f'[[package]]\nname = "{name}"\nversion = "{version}"\n'
+        if source:
+            text += f'source = "{source}"\n'
+        text += "\n"
+    return text
+
+
+def days_ago(days):
+    return (NOW - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class CheckLockAgeTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.dir.cleanup)
+        self.previous_cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.previous_cwd)
+        os.chdir(self.dir.name)
+        self.cargo_home = Path(self.dir.name, "cargo-home")
+        os.environ["CARGO_HOME"] = str(self.cargo_home)
+        self.addCleanup(os.environ.pop, "CARGO_HOME")
+        Path(".cargo").mkdir()
+        Path(".cargo/config.toml").write_text(
+            '[registry]\nglobal-min-publish-age = "7 days"\n'
+        )
+
+    def cache(self, name, **pubtimes):
+        """Write a sparse index cache entry: version=pubtime, or None for no field."""
+        path = self.cargo_home / "registry/index/index.crates.io-test/.cache"
+        path = path / check_dep_cooldown.index_path(name)
+        body = b"\x03\x02\x00\x00\x00" + b"etag\0"
+        for version, pubtime in pubtimes.items():
+            entry = {"vers": version}
+            if pubtime:
+                entry["pubtime"] = pubtime
+            body += version.encode() + b"\0" + json.dumps(entry).encode() + b"\0"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(body)
+
+    def commit_base(self, text):
+        Path("Cargo.lock").write_text(text)
+        # Ignore the user's git config so signing and hooks stay out.
+        env = dict(
+            os.environ,
+            GIT_CONFIG_GLOBAL=os.devnull,
+            GIT_CONFIG_NOSYSTEM="1",
+            GIT_AUTHOR_NAME="t",
+            GIT_AUTHOR_EMAIL="t@t",
+            GIT_COMMITTER_NAME="t",
+            GIT_COMMITTER_EMAIL="t@t",
+        )
+        for args in (
+            ["init", "-q"],
+            ["add", "Cargo.lock"],
+            ["commit", "-q", "-m", "base"],
+        ):
+            subprocess.run(["git", *args], check=True, env=env)
+
+    def test_young_version_added_since_base_fails(self):
+        self.commit_base(lock_text(("old", "1.0.0", CRATES_IO)))
+        Path("Cargo.lock").write_text(
+            lock_text(("old", "1.0.0", CRATES_IO), ("fresh", "2.0.0", CRATES_IO))
+        )
+        self.cache("fresh", **{"2.0.0": days_ago(6)})
+        added, problems = check_dep_cooldown.check("HEAD", NOW)
+        self.assertEqual(added, [("fresh", "2.0.0")])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("fresh 2.0.0", problems[0])
+        self.assertIn("6 days old, cooldown is 7 days", problems[0])
+
+    def test_aged_version_passes(self):
+        self.commit_base(lock_text())
+        Path("Cargo.lock").write_text(lock_text(("aged", "1.0.0", CRATES_IO)))
+        self.cache("aged", **{"1.0.0": days_ago(7)})
+        added, problems = check_dep_cooldown.check("HEAD", NOW)
+        self.assertEqual(added, [("aged", "1.0.0")])
+        self.assertEqual(problems, [])
+
+    def test_version_already_in_base_is_not_checked(self):
+        text = lock_text(("fresh", "2.0.0", CRATES_IO))
+        self.commit_base(text)
+        Path("Cargo.lock").write_text(text)
+        added, problems = check_dep_cooldown.check("HEAD", NOW)
+        self.assertEqual((added, problems), ([], []))
+
+    def test_git_and_path_sources_are_ignored(self):
+        self.commit_base(lock_text())
+        Path("Cargo.lock").write_text(
+            lock_text(
+                ("member", "0.1.0", None),
+                ("pinned", "0.2.0", "git+https://example.org/pinned#abc"),
+            )
+        )
+        added, problems = check_dep_cooldown.check("HEAD", NOW)
+        self.assertEqual((added, problems), ([], []))
+
+    def test_missing_cache_entry_fails_with_fetch_hint(self):
+        Path("Cargo.lock").write_text(lock_text(("unseen", "1.0.0", CRATES_IO)))
+        added, problems = check_dep_cooldown.check(None, NOW)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("unseen 1.0.0: not in the local index cache", problems[0])
+        self.assertIn("cargo fetch --locked", problems[0])
+
+    def test_entry_without_pubtime_fails(self):
+        Path("Cargo.lock").write_text(lock_text(("undated", "1.0.0", CRATES_IO)))
+        self.cache("undated", **{"1.0.0": None})
+        added, problems = check_dep_cooldown.check(None, NOW)
+        self.assertIn("not in the local index cache", problems[0])
+
+    def test_whole_lock_is_checked_without_a_base(self):
+        Path("Cargo.lock").write_text(
+            lock_text(("fresh", "2.0.0", CRATES_IO), ("aged", "1.0.0", CRATES_IO))
+        )
+        self.cache("fresh", **{"2.0.0": days_ago(1)})
+        self.cache("aged", **{"1.0.0": days_ago(30)})
+        added, problems = check_dep_cooldown.check(None, NOW)
+        self.assertEqual(added, [("aged", "1.0.0"), ("fresh", "2.0.0")])
+        self.assertEqual(len(problems), 1)
+        self.assertIn("fresh 2.0.0", problems[0])
+
+    def test_unknown_base_ref_is_an_error(self):
+        Path("Cargo.lock").write_text(lock_text())
+        subprocess.run(["git", "init", "-q"], check=True)
+        with self.assertRaises(SystemExit):
+            check_dep_cooldown.check("nosuchref", NOW)
+
+    def test_cooldown_accepts_rfc_durations(self):
+        for text, expected in (
+            ("7 days", timedelta(days=7)),
+            ("1 day", timedelta(days=1)),
+            ("12 hours", timedelta(hours=12)),
+            ("90 minutes", timedelta(minutes=90)),
+        ):
+            Path(".cargo/config.toml").write_text(
+                f'[registry]\nglobal-min-publish-age = "{text}"\n'
+            )
+            self.assertEqual(check_dep_cooldown.cooldown(), expected, text)
+
+    def test_cooldown_rejects_other_forms(self):
+        Path(".cargo/config.toml").write_text(
+            '[registry]\nglobal-min-publish-age = "P7D"\n'
+        )
+        with self.assertRaises(SystemExit):
+            check_dep_cooldown.cooldown()
+
+    def test_index_path_follows_cargo_layout(self):
+        self.assertEqual(check_dep_cooldown.index_path("a"), "1/a")
+        self.assertEqual(check_dep_cooldown.index_path("h2"), "2/h2")
+        self.assertEqual(check_dep_cooldown.index_path("log"), "3/l/log")
+        self.assertEqual(check_dep_cooldown.index_path("serde"), "se/rd/serde")
+        self.assertEqual(check_dep_cooldown.index_path("Inflector"), "in/fl/inflector")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/lock-edit
+++ b/scripts/lock-edit
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Edit one package entry in Cargo.lock so cargo re-resolves it.
+
+    lock-edit drop NAME[@VERSION]
+        Remove the entry. On the next resolve cargo adds the crate
+        back at its newest allowed version.
+
+    lock-edit set NAME VERSION
+        Rewrite the entry's version and remove its checksum. On the
+        next resolve cargo fills the checksum in and updates only
+        what the new version requires.
+
+Neither runs `cargo update -p`, which also rewrites unrelated
+entries (rust-lang/cargo#5529).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+LOCK = Path("Cargo.lock")
+BLOCK = re.compile(r"\[\[package\]\]\n(?:[^\n]+\n)+\n?")
+
+
+def main(argv):
+    if len(argv) == 3 and argv[1] == "drop":
+        name, _, version = argv[2].partition("@")
+        edit(name, version or None, drop)
+    elif len(argv) == 4 and argv[1] == "set":
+        edit(argv[2], None, lambda block: set_version(block, argv[3]))
+    else:
+        sys.exit(__doc__.strip())
+
+
+def edit(name, version, transform):
+    text = LOCK.read_text()
+    matches = [m for m in BLOCK.finditer(text) if entry(m.group())[0] == name]
+    if version:
+        matches = [m for m in matches if entry(m.group())[1] == version]
+    if not matches:
+        sys.exit(f"error: {name} is not in Cargo.lock")
+    if len(matches) > 1:
+        versions = ", ".join(entry(m.group())[1] for m in matches)
+        sys.exit(
+            f"error: {name} has several entries ({versions}); "
+            f"name one as {name}@VERSION"
+        )
+    match = matches[0]
+    if "\nsource = " not in match.group():
+        sys.exit(f"error: {name} is a workspace member, not a registry crate")
+    LOCK.write_text(
+        text[: match.start()] + transform(match.group()) + text[match.end() :]
+    )
+
+
+def entry(block):
+    name = re.search(r'^name = "([^"]+)"', block, re.M).group(1)
+    version = re.search(r'^version = "([^"]+)"', block, re.M).group(1)
+    return name, version
+
+
+def drop(block):
+    return ""
+
+
+def set_version(block, version):
+    block = re.sub(
+        r'^version = "[^"]+"', f'version = "{version}"', block, count=1, flags=re.M
+    )
+    return re.sub(r'^checksum = "[^"]+"\n', "", block, count=1, flags=re.M)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/lock_edit_test.py
+++ b/scripts/lock_edit_test.py
@@ -1,0 +1,91 @@
+"""Unit tests for lock-edit. Run with python3 -m unittest."""
+
+import importlib.machinery
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("lock-edit")
+CRATES_IO = "registry+https://github.com/rust-lang/crates.io-index"
+
+
+def load_script():
+    loader = importlib.machinery.SourceFileLoader("lock_edit", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+lock_edit = load_script()
+
+
+def entry(name, version, source=CRATES_IO, checksum="abc", deps=()):
+    text = f'[[package]]\nname = "{name}"\nversion = "{version}"\n'
+    if source:
+        text += f'source = "{source}"\nchecksum = "{checksum}"\n'
+    if deps:
+        text += "dependencies = [\n" + "".join(f' "{d}",\n' for d in deps) + "]\n"
+    return text + "\n"
+
+
+class LockEditTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.dir.cleanup)
+        self.addCleanup(os.chdir, os.getcwd())
+        os.chdir(self.dir.name)
+
+    def write(self, *entries):
+        text = "version = 4\n\n" + "".join(entries)
+        Path("Cargo.lock").write_text(text)
+        return text
+
+    def test_drop_removes_only_that_entry(self):
+        before = self.write(
+            entry("a", "1.0.0", deps=("b",)), entry("b", "2.0.0"), entry("c", "3.0.0")
+        )
+        lock_edit.main(["lock-edit", "drop", "b"])
+        self.assertEqual(
+            Path("Cargo.lock").read_text(), before.replace(entry("b", "2.0.0"), "")
+        )
+
+    def test_drop_needs_a_version_when_two_are_locked(self):
+        self.write(entry("dup", "1.0.0"), entry("dup", "2.0.0"))
+        with self.assertRaises(SystemExit) as raised:
+            lock_edit.main(["lock-edit", "drop", "dup"])
+        self.assertIn("dup@VERSION", str(raised.exception))
+        lock_edit.main(["lock-edit", "drop", "dup@1.0.0"])
+        text = Path("Cargo.lock").read_text()
+        self.assertNotIn('version = "1.0.0"', text)
+        self.assertIn('version = "2.0.0"', text)
+
+    def test_set_rewrites_version_and_drops_checksum(self):
+        self.write(entry("h2", "0.4.15", checksum="old"), entry("z", "1.0.0"))
+        lock_edit.main(["lock-edit", "set", "h2", "0.4.16"])
+        text = Path("Cargo.lock").read_text()
+        self.assertIn('name = "h2"\nversion = "0.4.16"\n', text)
+        self.assertNotIn("old", text)
+        self.assertIn(entry("z", "1.0.0"), text)
+
+    def test_missing_crate_is_an_error(self):
+        self.write(entry("a", "1.0.0"))
+        with self.assertRaises(SystemExit) as raised:
+            lock_edit.main(["lock-edit", "drop", "nope"])
+        self.assertIn("not in Cargo.lock", str(raised.exception))
+
+    def test_workspace_member_is_refused(self):
+        self.write(entry("member", "0.1.0", source=None))
+        with self.assertRaises(SystemExit) as raised:
+            lock_edit.main(["lock-edit", "set", "member", "0.2.0"])
+        self.assertIn("workspace member", str(raised.exception))
+
+    def test_usage_on_bad_arguments(self):
+        with self.assertRaises(SystemExit):
+            lock_edit.main(["lock-edit", "drop"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools.just
+++ b/tools.just
@@ -3,17 +3,11 @@
 # setup-tools installs a missing tool if it is not already installed. The build
 # container runs this recipe, so these versions decide what runs in CI.
 
-COOLDOWN_VERSION := "0.3.4"
 DENY_VERSION := "0.20.2"
 
 # Install the cargo tools the recipes use
 [group('setup')]
 setup-tools:
-    @if command -v cargo-cooldown >/dev/null; then \
-        echo "cargo-cooldown already installed; using the system copy"; \
-    else \
-        cargo install --locked cargo-cooldown --version {{COOLDOWN_VERSION}}; \
-    fi
     @if command -v cargo-deny >/dev/null; then \
         echo "cargo-deny already installed; using the system copy"; \
     else \


### PR DESCRIPTION
Move the dependency cooldown into cargo and gate pull requests on it.

Cargo's own `min-publish-age` setting ([RFC 3923]) now holds every crate release back for seven days before it may enter `Cargo.lock`, set in `.cargo/config.toml`. It is nightly-only until cargo 1.100, the next stable release, so the `deps` recipes run `cargo +nightly` for now. cargo-cooldown and `cooldown.toml` go away: it skipped the cooldown for a single-crate update because it read the crate name as a workspace selector (dertin/cargo-cooldown#23), and it could not cover a plain `cargo update`.

[RFC 3923]: https://rust-lang.github.io/rfcs/3923-cargo-min-publish-age.html

A new pull-request job, "Check dep cooldown", fails when the lock gains a crates.io version younger than the window relative to the base branch. The script reads publish times from cargo's local index cache and never opens a connection of its own; `just check-dep-cooldown` runs it locally. A young version that has to go in, such as a security fix, fails the job and a maintainer merges with the reason in the pull request.

CONTRIBUTING.md documents the related workflows.

Parts of this scheme are inspired by Mullvad's mullvad/mullvadvpn-app#10798: a check of the versions added by a pull request, and `pubtime` from the crates.io index used. We make a few improvements: reading cargo's local cache  instead of reading the index via the network, avoiding an allowlist, running inside our build container, and having unit tests.

### Follow-up

When cargo 1.100 is released: drop the `[unstable]` table and the `+nightly` from the `deps` recipes, require 1.100 through `rust-toolchain.toml`, and move the CI image to the 1.100 tag. An issue will track it.
